### PR TITLE
fix: correct typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,5 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-.DS_Store%  
+.DS_Store
 .vscode


### PR DESCRIPTION
A minimal typo fix inside the .gitignore