### PR TITLE
feat: add seed knowledge base documents

### DIFF
--- a/src/rag/data/adr_001_why_fastapi.md
+++ b/src/rag/data/adr_001_why_fastapi.md
@@ -1,0 +1,61 @@
+# adr_001_why_fastapi.md
+
+## ADR-001 Why FastAPI
+
+Status: Accepted
+
+## Context
+
+Need API framework for agent endpoints and RAG service.
+
+---
+
+## Decision
+
+Use FastAPI.
+
+---
+
+## Reasons
+
+Chosen for:
+
+* Python-native fit
+* Pydantic validation
+* Async support
+* Good developer velocity
+* Strong ecosystem
+
+---
+
+## Tradeoffs Accepted
+
+* Not minimal as Flask
+* Some framework abstraction overhead
+* Async misuse can add complexity
+
+Accepted.
+
+---
+
+## Alternatives Considered
+
+Flask:
+Simpler, less structure.
+
+Django:
+Too heavy for current scope.
+
+---
+
+## Consequences
+
+API schemas become first-class.
+Validation shifts earlier.
+Good fit for agent interfaces.
+
+---
+
+## Informal Note
+
+We chose boring-good over novel-interesting.

--- a/src/rag/data/adr_002_why_lancedb.md
+++ b/src/rag/data/adr_002_why_lancedb.md
@@ -1,0 +1,59 @@
+# adr_002_why_lancedb.md
+
+## ADR-002 Why LanceDB
+
+Status: Accepted
+
+## Context
+
+Need vector store for RAG retrieval.
+
+---
+
+## Decision
+
+Use LanceDB.
+
+---
+
+## Reasons
+
+Selected for:
+
+* Good Python ergonomics
+* Local-first simplicity
+* Suitable for project scale
+* Vector + tabular model appealing
+* Easy experimentation
+
+---
+
+## Tradeoffs Accepted
+
+Not highest-scale option.
+Some production ecosystems more mature elsewhere.
+
+Accepted for current needs.
+
+---
+
+## Alternatives Considered
+
+FAISS:
+Strong, but less database-like workflow.
+
+Managed vector DB:
+Useful later, heavier now.
+
+---
+
+## Consequences
+
+Fast iteration favored.
+Can revisit later.
+
+---
+
+## Informal Note
+
+Optimize for learning leverage before hyperscale fantasies.

--- a/src/rag/data/bad_pull_request_example.md
+++ b/src/rag/data/bad_pull_request_example.md
@@ -1,0 +1,31 @@
+# bad_pull_request_example.md
+
+## Example of Problematic Pull Request
+
+Title:
+fixes and updates
+
+Description:
+Updated a bunch of things related to agents, retrieval, prompts, UI and deployment.
+
+Changed:
+
+* prompt logic
+* schemas
+* frontend layout
+* logging
+* deployment config
+
+Testing:
+Works locally.
+
+Problems:
+
+* scope too broad
+* no rationale
+* many concerns mixed
+* no risk discussion
+* impossible review surface
+
+Unofficial diagnosis:
+This is several PRs wearing a trench coat.

--- a/src/rag/data/branching_and_git_workflow.md
+++ b/src/rag/data/branching_and_git_workflow.md
@@ -1,0 +1,56 @@
+# branching_and_git_workflow.md
+
+## Branching and Git Workflow
+
+Default model:
+
+* main is protected
+* work happens in feature branches
+* changes land through pull requests
+
+---
+
+## Branch Naming
+
+Prefer:
+feature/...
+fix/...
+chore/...
+
+Examples:
+feature/seed-rag-knowledge-base
+fix/handle-tool-timeout
+
+Names should explain intent.
+
+---
+
+## Commit Guidance
+
+Prefer small atomic commits.
+
+Good:
+feat: add retrieval fallback handling
+
+Bad:
+stuff
+
+Commits are historical evidence.
+
+---
+
+## Rules
+
+* No direct commits to main
+* Rebase or merge per team convention
+* Keep branches short-lived
+* Avoid giant divergence
+
+Long-lived branches grow teeth.
+
+---
+
+## Informal Rule
+
+If resolving merge conflicts feels archaeological,
+branch lived too long.

--- a/src/rag/data/code_review_guidelines.md
+++ b/src/rag/data/code_review_guidelines.md
@@ -1,0 +1,324 @@
+# code_review_guidelines.md
+
+## Code Review Guidelines — 404 Brain Not Found
+
+**Version:** 0.1
+**Purpose:** Shared expectations for writing, reviewing and merging pull requests.
+
+---
+
+# Why We Review
+
+Code review exists to improve:
+
+* Correctness
+* Maintainability
+* Shared understanding
+* Risk detection
+* Learning
+
+It is not a ritual before merge.
+It is part of engineering.
+
+---
+
+# What Good Pull Requests Look Like
+
+Good PRs are usually:
+
+* Small enough to review in one sitting
+* Focused on one coherent change
+* Clear about intent
+* Honest about tradeoffs
+
+A reviewer should not need detective skills.
+
+---
+
+## A Good PR Description Includes
+
+* What changed
+* Why it changed
+* Risks or edge cases
+* Testing performed
+* Questions where feedback is wanted
+
+Template:
+
+## Summary
+
+Short explanation.
+
+## Why
+
+Problem addressed.
+
+## Testing
+
+What was validated.
+
+## Risks
+
+Known uncertainties.
+
+---
+
+# PR Size Guidance
+
+Rough preference:
+
+* Small: ideal
+* Medium: normal
+* Large: justify
+* Massive: probably should be split
+
+If someone needs snacks before reviewing your PR, it may be too large.
+
+---
+
+# Before Opening a PR
+
+Ask yourself:
+
+* Would I understand this PR cold?
+* Is scope too broad?
+* Are assumptions explained?
+* Did I update docs if needed?
+* Would I merge this if someone else wrote it?
+
+That last question catches things.
+
+---
+
+# What Reviewers Look For
+
+Reviewers commonly check:
+
+## Correctness
+
+* Does it work?
+* Are edge cases missed?
+* Can it fail dangerously?
+
+---
+
+## Design
+
+* Is complexity justified?
+* Is simpler possible?
+* Does it fit surrounding patterns?
+
+---
+
+## Maintainability
+
+* Can others support this later?
+* Is naming understandable?
+* Is hidden coupling introduced?
+
+---
+
+## Operational Risk
+
+* Logging impact?
+* Deployment implications?
+* Failure modes?
+
+---
+
+# Review Comments
+
+Common kinds of comments:
+
+**Blocking**
+Must resolve before merge.
+
+**Non-blocking suggestion**
+Improvement opportunity.
+
+**Question**
+Reviewer uncertainty.
+
+Treat these differently.
+
+Not every comment is a stop sign.
+
+---
+
+# How To Respond To Review Feedback
+
+Good responses:
+
+* Revise the code
+* Explain reasoning respectfully
+* Ask follow-ups
+* Disagree when justified, calmly
+
+"Fixed" is rarely a useful response by itself.
+
+---
+
+# What Review Is Not For
+
+Review is not for:
+
+* Personal criticism
+* Showing superiority
+* Rewriting everything to personal taste
+* Architecture ambushes unrelated to scope
+
+Do not smuggle redesigns into typo fixes.
+
+---
+
+# Approval Expectations
+
+Default:
+
+* At least one meaningful review
+* Higher-risk changes may require more
+* Author should not self-approve around safeguards
+
+Approval means:
+
+Reasonable confidence.
+Not perfection guarantee.
+
+---
+
+# When To Escalate Instead Of Merge
+
+Escalate if PR includes:
+
+* Security concerns
+* Data integrity risk
+* Architectural boundary changes
+* Unclear ownership conflicts
+
+Some PRs are decisions disguised as code.
+
+Those need discussion.
+
+---
+
+# Common Rookie PR Mistakes
+
+Frequent patterns:
+
+* PR too large
+* No context in description
+* Defensive response to feedback
+* Mixing many concerns in one branch
+* Opening PR only when "finished"
+
+Open earlier.
+
+Draft PRs exist for a reason.
+
+---
+
+# Common Reviewer Mistakes
+
+Also common:
+
+* Nitpicking style over substance
+* Vague comments
+* Drive-by approvals without reading
+* Turning review into ego theater
+
+"Looks good" on a 700-line PR is suspicious.
+
+---
+
+# Review Latency Norm
+
+Do not leave teammates waiting indefinitely.
+
+Review is part of delivery, not optional volunteer work.
+
+If overloaded:
+
+* acknowledge
+* set expectation
+* redirect if needed
+
+---
+
+# Special Guidance for AI/LLM Code
+
+Review additionally for:
+
+* Prompt behavior risks
+* Schema validation
+* Tool failure handling
+* Hallucination guardrails
+* Evaluation coverage
+
+Model output logic deserves skepticism.
+
+---
+
+# Merge Readiness Checklist
+
+Before merge:
+
+* [ ] Tests pass
+* [ ] Review comments addressed
+* [ ] Risks understood
+* [ ] Docs updated if needed
+* [ ] Rollback path known
+
+Then merge.
+Monitor.
+Breathe.
+
+---
+
+# Informal Review Principles
+
+## The Reviewer Is Not The Enemy
+
+Good reviewers reduce incidents.
+
+---
+
+## The Three-Question Rule
+
+Before major criticism, ask:
+
+* Is it wrong?
+* Is it risky?
+* Or is it just not how I would do it?
+
+Only the first two may justify blocking.
+
+---
+
+## The Friday Rule
+
+Deploy skepticism increases late Friday.
+
+This is rational.
+
+---
+
+# Example of a Strong Review Comment
+
+Weak:
+
+> This seems bad.
+
+Better:
+
+> I may be missing context, but this introduces retry logic without timeout bounds. Could this create runaway behavior under failure?
+
+Precision scales.
+
+---
+
+**Related documents**
+
+* good_pull_request_example.md
+* bad_pull_request_example.md
+* branching_and_git_workflow.md
+* rookie_mistakes.md

--- a/src/rag/data/communication_norms.md
+++ b/src/rag/data/communication_norms.md
@@ -1,0 +1,101 @@
+# communication_norms.md
+
+## Communication Norms — 404 Brain Not Found
+
+# Async First
+
+Default to asynchronous communication unless urgency demands otherwise.
+
+Bring:
+
+* context
+* concrete question
+* what you tried
+
+---
+
+# When To Ping
+
+Ping teammates for:
+
+* blockers
+* dependencies
+* time-sensitive clarification
+
+Do not use “quick question?” as a standalone message.
+Ask the question.
+
+---
+
+# Escalation Messaging
+
+Good:
+“Deploy failing after config change, logs suggest secret mismatch. Can someone sanity-check?”
+
+Bad:
+“Help.”
+
+---
+
+# Response Expectations
+
+Not every chat message is urgent.
+Respect focus.
+
+Urgent should mean urgent.
+
+---
+
+# Meetings
+
+Come with:
+
+* context
+* decisions needed
+* risks surfaced
+
+Meetings are expensive.
+Use intentionally.
+
+---
+
+# Written Communication Principle
+
+Optimize for messages readable without extra explanation.
+
+Future readers exist.
+
+---
+
+# Ask In Public By Default
+
+Use public channels unless privacy requires otherwise.
+
+Private DMs hide reusable answers.
+
+---
+
+# The Two-Bounce Rule
+
+If a chat thread exceeds two clarification bounces,
+consider a call.
+
+---
+
+# Anti-Patterns
+
+Avoid:
+
+* vague urgency
+* hidden blockers
+* passive-aggressive ambiguity
+* weaponized silence
+
+---
+
+# Informal Principle
+
+Ping people like you would want to be pinged.
+
+Related:
+when_to_ask_for_help.md

--- a/src/rag/data/deployment_runbook.md
+++ b/src/rag/data/deployment_runbook.md
@@ -1,0 +1,49 @@
+# deployment_runbook.md
+
+## Deployment Runbook
+
+# Before Deploy
+
+Verify:
+
+* tests green
+* config reviewed
+* rollback path known
+* monitoring available
+
+---
+
+## Deploy Sequence
+
+1. Announce if needed
+2. Deploy
+3. Verify health
+4. Check logs/metrics
+5. Watch for regressions
+
+Deploy is not finished at step 2.
+
+---
+
+## If Things Go Wrong
+
+* Stabilize
+* Roll back if needed
+* Escalate early
+* Capture facts
+
+Do not improvise heroically.
+
+---
+
+## The Calm Rule
+
+Move deliberately.
+Fast panic is slower than calm action.
+
+---
+
+## Friday Rule
+
+Be extra skeptical of risky Friday deploys.
+The rule exists because history exists.

--- a/src/rag/data/employee_handbook.md
+++ b/src/rag/data/employee_handbook.md
@@ -1,0 +1,583 @@
+# employee_handbook.md
+
+## Employee Handbook — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Interns, junior engineers, and new team members
+**Purpose:** Provide a lightweight but realistic internal handbook for onboarding and daily collaboration.
+
+---
+
+# Welcome
+
+Welcome to **404 Brain Not Found**.
+
+We build practical AI systems with a bias toward experimentation, reliability, and thoughtful engineering.
+
+As a small technical organization, we expect everyone — including interns — to contribute meaningfully, ask questions early, and improve systems as they learn.
+
+This handbook explains how we work, what we expect, and how to navigate the organization.
+
+---
+
+# Our Principles
+
+We try to optimize for:
+
+1. **Clarity over complexity**
+   Prefer understandable systems over clever ones.
+
+2. **Ship small, improve often**
+   Iteration beats overdesign.
+
+3. **Evidence over opinion**
+   Use data, experiments and reasoning.
+
+4. **Escalate risks early**
+   Bad surprises are worse than early warnings.
+
+5. **Documentation is part of the work**
+   If it is not documented, it probably does not scale.
+
+---
+
+# Team Roles
+
+## Intern / Junior Engineer
+
+Expected to:
+
+* Complete onboarding tasks
+* Ask questions when blocked
+* Contribute code, documentation or analysis
+* Participate in reviews
+* Surface uncertainty early
+* Learn team norms and workflows
+
+You are not expected to know everything.
+You are expected to reason, communicate and learn.
+
+---
+
+## Engineer
+
+Responsible for:
+
+* Delivery and implementation
+* Code reviews
+* Technical guidance
+* Maintaining quality standards
+* Supporting onboarding
+
+---
+
+## Tech Lead
+
+Responsible for:
+
+* Architecture decisions
+* Technical prioritization
+* Risk escalation
+* Mentoring
+* Final approval for major changes
+
+---
+
+# How We Work
+
+## Default Work Pattern
+
+Most work follows:
+
+* Ticket or task definition
+* Clarify requirements
+* Implement in small increments
+* Open pull request early
+* Iterate through feedback
+* Merge when approved
+
+Work in visible increments.
+Avoid long-lived hidden work.
+
+---
+
+## Ownership
+
+If you pick up a task, you own:
+
+* Understanding the problem
+* Communicating blockers
+* Asking for help when needed
+* Leaving the work in a better state
+
+Ownership does not mean solving everything alone.
+
+---
+
+# Communication Channels
+
+## Chat (Slack/Teams)
+
+Used for:
+
+* Quick questions
+* Coordination
+* Async updates
+* Lightweight discussions
+
+Good messages include:
+
+* Context
+* What you tried
+* Specific ask
+
+Example:
+
+Bad:
+
+> Deploy broken, help.
+
+Better:
+
+> Staging deploy failed after config change. Checked logs and rollback notes, suspect env variable mismatch. Can someone sanity-check?
+
+---
+
+## Meetings
+
+Recurring meetings may include:
+
+* Daily check-in
+* Planning
+* Demo/review
+* Retrospective
+
+Come prepared.
+Short meetings should stay short.
+
+---
+
+## Documentation
+
+Use documentation for:
+
+* Decisions
+* Runbooks
+* Architecture notes
+* Repeated questions
+
+Don’t bury operational knowledge in chat threads.
+
+---
+
+# Expectations for New Team Members
+
+## First 30 Days
+
+You should aim to:
+
+* Understand system basics
+* Ship at least one small contribution
+* Participate in a code review
+* Learn escalation paths
+* Become productive in core tools
+
+Progress matters more than speed.
+
+---
+
+## Asking Questions
+
+Ask early when:
+
+* You are blocked more than ~30–60 minutes
+* You might introduce risk
+* Requirements are ambiguous
+* A decision affects others
+
+Before asking:
+
+1. Read relevant documentation
+2. Try a reasonable approach
+3. Bring your reasoning with the question
+
+---
+
+# Feedback Culture
+
+Feedback is expected.
+
+Review feedback critiques work, not people.
+
+Good responses to feedback:
+
+* Ask clarifying questions
+* Revise thoughtfully
+* Challenge respectfully if needed
+
+Defensiveness slows learning.
+
+---
+
+# Escalation Guidance
+
+Use this model:
+
+## Proceed Yourself (Green)
+
+Examples:
+
+* Small refactors
+* Documentation improvements
+* Minor bug fixes
+* Non-risky experiments
+
+---
+
+## Ask Teammate First (Yellow)
+
+Examples:
+
+* Unclear design choices
+* Shared code ownership areas
+* Changes affecting interfaces
+* Suspicious test failures
+
+---
+
+## Escalate to Lead (Red)
+
+Examples:
+
+* Security concerns
+* Production risks
+* Incident indicators
+* Architectural changes
+* Data integrity uncertainty
+
+Escalating early is considered good judgment.
+
+---
+
+# Working Agreements
+
+We generally prefer:
+
+* Small PRs over massive PRs
+* Explicit assumptions over hidden assumptions
+* Reproducible fixes over manual heroics
+* Calm incident handling over improvisation
+
+Avoid:
+
+* Silent blockers
+* Scope creep without discussion
+* “Works on my machine” handoffs
+* Merging unreviewed risky code
+
+---
+
+# Time and Availability
+
+Respect focus time.
+
+Not every message requires immediate response.
+
+Use urgency intentionally.
+
+If something is urgent, say why.
+
+---
+
+# Tooling Expectations
+
+You are expected to learn and use:
+
+* Git and pull requests
+* Issue tracking
+* Local development setup
+* Testing basics
+* Documentation conventions
+
+Advanced expertise is not assumed on day one.
+
+---
+
+# What Good Interns Tend To Do
+
+Patterns we often value:
+
+* Ask thoughtful questions
+* Document what they learn
+* Improve small things proactively
+* Accept feedback quickly
+* Surface risks early
+* Leave breadcrumbs for others
+
+Signal reliability before trying to signal brilliance.
+
+---
+
+# Common Anti-Patterns
+
+Watch for these:
+
+* Waiting too long before asking for help
+* Overengineering simple tasks
+* Treating review comments as personal criticism
+* Solving symptoms instead of root causes
+* Assuming undocumented norms
+
+These are common, fixable mistakes.
+
+---
+
+# Decision Making
+
+Many decisions are reversible.
+
+For reversible decisions:
+
+* decide fast
+* test
+* adjust
+
+For hard-to-reverse decisions:
+
+* slow down
+* gather evidence
+* involve others
+
+---
+
+# Security and Confidentiality
+
+Basic rules:
+
+* Never commit secrets
+* Use approved access paths
+* Ask before using production data
+* Report accidental exposure immediately
+
+Security mistakes hidden become incidents.
+
+---
+
+# When Unsure
+
+Default sequence:
+
+1. Check documentation
+2. Check examples
+3. Ask teammate
+4. Escalate if risk exists
+
+Do not stay stuck alone.
+
+---
+
+# Employment Basics
+
+## Working Hours
+
+Standard expectation is roughly 40 hours per week.
+
+Core collaboration hours are normally:
+
+* 09:00–15:00 available for meetings and collaboration
+* Flexible time outside this is common
+
+We optimize for outcomes, not performative online presence.
+
+---
+
+## Remote and Hybrid Work
+
+Hybrid work is normal.
+
+Default expectation:
+
+* Be reachable during core hours
+* Keep calendars updated
+* Communicate when working asynchronously
+
+Remote does not mean invisible.
+
+---
+
+## Lunch and Breaks
+
+Take lunch.
+
+Recommended lunch break:
+
+* 45–60 minutes
+
+Short breaks are normal and encouraged.
+
+We strongly encourage food before making production decisions.
+
+Historical evidence supports this.
+
+---
+
+## Sick Leave
+
+If sick:
+
+* Notify your team lead or team channel early
+* Do not work through illness unless genuinely optional and light
+* Recovery outranks performative availability
+
+---
+
+## Vacation
+
+Vacation should be coordinated early and documented.
+
+Avoid disappearing with sole ownership of critical work.
+
+If only one person understands a system before vacation, that is a systems problem.
+
+---
+
+# Office Conduct
+
+## Shared Spaces
+
+Leave shared spaces usable.
+
+This includes:
+
+* Clean up after meals
+* Label food if storing it
+* Do not occupy meeting rooms as private offices all day
+
+If you make the last coffee and do not start a new pot, consequences may be mostly social.
+
+---
+
+## Smoking and Vaping
+
+Only in designated areas.
+
+Never near entrances, ventilation or outdoor collaboration areas.
+
+---
+
+## Noise and Focus
+
+Use judgment with interruptions.
+
+When someone is visibly in deep focus, prefer async questions unless urgent.
+
+---
+
+## Office Cat Policy
+
+If the office cat occupies your chair, that chair may be considered temporarily reassigned.
+
+---
+
+# Information Handling
+
+## Information Classification
+
+We use four practical classes:
+
+### Public
+
+Safe to share externally.
+
+### Internal
+
+Default internal material.
+
+### Confidential
+
+Restricted to relevant teams.
+
+### Restricted
+
+Sensitive systems, credentials, incident data or regulated information.
+
+When unsure, classify upward.
+
+---
+
+## AI Tool Usage
+
+Do not paste confidential or restricted data into external AI systems unless explicitly approved.
+
+Questions about this should be escalated.
+
+---
+
+# Acceptable Security Practices
+
+Expected:
+
+* Lock devices when away
+* Use approved password management
+* Never share credentials
+* Never commit secrets
+* Use least privilege access
+
+Security incidents hidden tend to grow.
+
+---
+
+# Benefits and Team Culture
+
+Typical cultural norms may include:
+
+* Team lunches
+* Demo Fridays
+* Learning sessions
+* Pairing hours
+* Conference or study budget where applicable
+
+First Friday demo failures are considered a rite of passage.
+
+---
+
+# Informal Internal Principles
+
+## The Two-Coffee Rule
+
+Do not escalate architecture debates before at least two people have had coffee.
+
+---
+
+## The Rubber Duck Clause
+
+Before interrupting a senior engineer, explain the problem once to a duck, plant or empty terminal.
+
+---
+
+## The 404 Principle
+
+Confusion is not failure.
+
+It is a documented state.
+
+---
+
+# Final Note
+
+We do not expect perfect decisions.
+
+We expect thoughtful decisions, visible reasoning and steady improvement.
+
+That is how people grow here.
+
+---
+
+**Related documents:**
+
+* onboarding_checklist.md
+* engineering_handbook.md
+* code_review_guidelines.md
+* incident_escalation_policy.md
+* rookie_mistakes.md
+* what_good_interns_do.md

--- a/src/rag/data/engineering_handbook.md
+++ b/src/rag/data/engineering_handbook.md
@@ -1,0 +1,291 @@
+# engineering_handbook.md
+
+## Engineering Handbook — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Engineers, interns, technical contributors
+
+---
+
+# Purpose
+
+This handbook describes how we build software.
+
+Employee handbook explains how we work together.
+This document explains how we engineer.
+
+---
+
+# Engineering Philosophy
+
+We generally prefer:
+
+* Simple systems over impressive systems
+* Observable systems over opaque systems
+* Small changes over heroic rewrites
+* Reliable boring solutions over fragile cleverness
+
+Default question:
+
+Can we make this simpler?
+
+---
+
+# Typical Development Flow
+
+Most work follows:
+
+1. Pick up ticket
+2. Clarify scope
+3. Sketch approach
+4. Implement small increments
+5. Open PR early
+6. Review and revise
+7. Merge and monitor
+
+Merge is not the end of work.
+Production behavior matters.
+
+---
+
+# Definition of Done
+
+Work is generally done when:
+
+* Requirements addressed
+* Tests pass
+* Edge cases considered
+* Documentation updated
+* Review completed
+* Monitoring implications considered
+
+"It runs locally" is not definition of done.
+
+---
+
+# Code Principles
+
+## Readability
+
+Code is written for future humans.
+
+Including tired future-you.
+
+---
+
+## Prefer Explicitness
+
+Hidden magic ages badly.
+
+Prefer:
+
+* Clear names
+* Small functions
+* Predictable interfaces
+* Visible error handling
+
+---
+
+## Comments
+
+Comment why.
+Not what obvious code does.
+
+---
+
+# Testing Expectations
+
+Reasonable expectations:
+
+* Unit tests for logic
+* Integration tests for flows
+* Manual validation for risky changes
+
+No one expects exhaustive tests for every prototype.
+
+But zero testing should feel suspicious.
+
+---
+
+# Git and Branching
+
+Typical model:
+
+* Feature branches
+* Pull requests for changes
+* Small atomic commits preferred
+
+Commit messages should help archaeology.
+
+Future debugging is time travel.
+Leave clues.
+
+---
+
+# Pull Requests
+
+Good PRs tend to:
+
+* Solve one coherent thing
+* Explain why change exists
+* Note risks or tradeoffs
+* Stay reviewable in size
+
+Large mysterious PRs are called novels.
+
+Novels are rarely merged happily.
+
+---
+
+# Code Review Norms
+
+Review looks for:
+
+* Correctness
+* Maintainability
+* Risk
+* Simplicity
+* Learning opportunities
+
+Review is collaboration, not border control.
+
+---
+
+# Error Handling
+
+Prefer:
+
+* Fail clearly
+* Log useful context
+* Degrade gracefully where possible
+* Use fallback behavior intentionally
+
+Silent failure is usually just delayed failure.
+
+---
+
+# Observability
+
+Think about:
+
+* Logs
+* Metrics
+* Traces
+* Alerts
+
+If a system breaks and no one can tell why, monitoring is incomplete.
+
+---
+
+# Deployments
+
+Normal principles:
+
+* Small changes safer than giant releases
+* Use checklists
+* Have rollback path
+* Never assume deployment succeeded
+
+Trust, then verify.
+
+---
+
+# Working with AI Systems
+
+For LLM and retrieval systems, additionally consider:
+
+* Grounding
+* Evaluation
+* Prompt behavior
+* Fallbacks
+* Hallucination risk
+* Tool failure modes
+
+Model output is input requiring scrutiny.
+
+---
+
+# Escalation in Engineering Decisions
+
+Proceed yourself:
+
+* Refactors
+* Small improvements
+* Documentation fixes
+
+Ask teammate:
+
+* Interface changes
+* Design uncertainty
+* Shared ownership code
+
+Escalate lead:
+
+* Security risk
+* Architecture shifts
+* Production instability
+
+---
+
+# Engineering Anti-Patterns
+
+Watch for:
+
+* Premature abstraction
+* Overengineering
+* Cargo-cult patterns
+* Hidden coupling
+* Copy-paste architecture
+
+And the classic:
+
+"We’ll clean it up later."
+
+History suggests otherwise.
+
+---
+
+# Design Biases We Prefer
+
+When tradeoffs are close, bias toward:
+
+* Maintainability
+* Reversibility
+* Operational simplicity
+* Clear ownership
+
+Elegant systems that no one can operate are not wins.
+
+---
+
+# The Carbon–Silicon Principle
+
+Humans make judgment.
+Systems provide leverage.
+
+Good engineering augments people.
+It does not hide reasoning from them.
+
+---
+
+# Informal Engineering Commandments
+
+1. Do not deploy on vibes.
+
+2. Read the error before rewriting the system.
+
+3. If three people debug manually, automate it.
+
+4. If everyone fears touching code, the code owns you.
+
+5. There shall be no unhandled exceptions left behind.
+
+---
+
+**Related documents**
+
+* code_review_guidelines.md
+* branching_and_git_workflow.md
+* deployment_runbook.md
+* adr_001_why_fastapi.md
+* adr_004_error_handling_strategy.md

--- a/src/rag/data/example_design_doc.md
+++ b/src/rag/data/example_design_doc.md
@@ -1,0 +1,36 @@
+# example_design_doc.md
+
+## Mini Design Spec Example
+
+Problem:
+Interns repeatedly ask similar onboarding questions.
+
+Proposal:
+Add retrieval-backed onboarding assistant with escalation guidance.
+
+Scope:
+
+* answer questions over knowledge base
+* provide escalation suggestions
+* log unanswered questions
+
+Out of scope:
+
+* autonomous task execution
+* ticket creation
+
+Risks:
+
+* weak retrieval relevance
+* hallucination risk
+* stale documentation
+
+Mitigations:
+
+* evaluation
+* fallback responses
+* document ownership
+
+Decision note:
+Start narrow.
+Expand after evidence.

--- a/src/rag/data/example_incident_postmortem.md
+++ b/src/rag/data/example_incident_postmortem.md
@@ -1,0 +1,31 @@
+# example_incident_postmortem.md
+
+## Incident Postmortem Example
+
+Incident:
+RAG assistant returned stale architectural guidance after outdated chunks dominated retrieval.
+
+Impact:
+Incorrect guidance shown internally.
+No customer harm.
+
+Root Cause:
+Chunk refresh pipeline had silently failed.
+
+Contributing Factors:
+
+* missing freshness checks
+* weak monitoring
+* overconfidence in retrieval quality
+
+Resolution:
+
+* fixed ingest job
+* added freshness metadata
+* added retrieval evaluation checks
+
+Lessons:
+Retrieval quality is an operational concern, not only model concern.
+
+Blameless Note:
+Failure emerged from system gaps, not individual negligence.

--- a/src/rag/data/good_pull_request_example.md
+++ b/src/rag/data/good_pull_request_example.md
@@ -1,0 +1,31 @@
+# good_pull_request_example.md
+
+## Example of Strong Pull Request
+
+Title:
+feat: add fallback response when retrieval returns no context
+
+Summary:
+Adds guarded fallback behavior so assistant returns uncertainty response rather than hallucinated answer when retrieval yields empty results.
+
+Why:
+Observed failure mode during testing.
+
+Testing:
+
+* unit test added
+* empty-context scenario tested
+* regression check passed
+
+Risks:
+Minimal, touches response routing only.
+
+Why this is good:
+
+* focused scope
+* explains intent
+* documents risk
+* includes validation
+
+Reviewer note:
+Good example of small, reviewable change.

--- a/src/rag/data/incident_escalation_policy.md
+++ b/src/rag/data/incident_escalation_policy.md
@@ -1,0 +1,145 @@
+# incident_escalation_policy.md
+
+## Incident Escalation Policy — 404 Brain Not Found
+
+**Version:** 0.1
+
+# Purpose
+
+Defines when and how operational or security incidents should be escalated.
+
+---
+
+# Severity Levels
+
+## Sev 4 — Minor
+
+Low impact.
+Localized issue.
+No customer harm.
+
+Examples:
+
+* Noncritical bug
+* Internal tool degraded
+* Single-user issue
+
+Default: solve in team.
+
+---
+
+## Sev 3 — Moderate
+
+Customer-facing degradation.
+Limited impact.
+
+Examples:
+
+* Partial service outage
+* Repeated failed deploys
+* Retrieval quality collapse in production
+
+Escalate to responsible engineer.
+
+---
+
+## Sev 2 — Major
+
+Significant customer or business impact.
+
+Examples:
+
+* Production instability
+* Data corruption risk
+* Security anomaly
+* Failed rollback
+
+Escalate immediately.
+
+---
+
+## Sev 1 — Critical
+
+Company-threatening event.
+
+Examples:
+
+* Major outage
+* Credential compromise
+* Sensitive data exposure
+* Autonomous model action causing harm
+
+Wake people up.
+
+---
+
+# Escalation Rules
+
+Escalate early if:
+
+* Unsure of severity
+* Blast radius unknown
+* Security may be involved
+* You think “maybe this is serious”
+
+That thought is often the escalation trigger.
+
+---
+
+# Incident Principles
+
+1. Stabilize before optimize.
+2. Contain before explain.
+3. Facts before theories.
+4. No blame during active incident.
+
+---
+
+# What To Include In Escalation
+
+Provide:
+
+* What happened
+* Current impact
+* What you observed
+* What you already tried
+* What risk worries you
+
+Good escalation reduces chaos.
+
+---
+
+# Things You Never Wait On
+
+Immediately escalate:
+
+* Possible secrets leak
+* Customer data exposure
+* Production deletion risk
+* Suspicious model/tool behavior
+
+Minutes matter.
+
+---
+
+# Rookie Rule
+
+When unsure whether to escalate:
+Escalate.
+
+False-positive escalation is usually cheaper than missed incidents.
+
+---
+
+# Informal Law
+
+If someone says
+“this is probably fine”
+during an incident,
+verify.
+
+---
+
+Related:
+example_incident_postmortem.md
+incident_lessons_learned.md

--- a/src/rag/data/onboarding_checklist.md
+++ b/src/rag/data/onboarding_checklist.md
@@ -1,0 +1,294 @@
+# onboarding_checklist.md
+
+## New Joiner Onboarding Checklist — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Interns and junior engineers
+**Purpose:** First-week and first-30-day onboarding guide.
+
+---
+
+# Before Day One
+
+## Access and Accounts
+
+Confirm access to:
+
+* Company email
+* Chat (Slack/Teams)
+* GitHub organization
+* Issue tracker
+* Documentation/wiki
+* Cloud/dev environments
+* Password manager / secrets access (if approved)
+
+If something is missing, raise it early.
+
+Day one should not begin with credential archaeology.
+
+---
+
+## Hardware Setup
+
+Verify:
+
+* Laptop provisioned
+* Required software installed
+* VPN (if needed)
+* SSH keys configured
+* Development environment tested
+
+Success criterion:
+
+Clone repo.
+Run something.
+Break nothing.
+
+---
+
+# Day One
+
+## Meet the Team
+
+Complete introductions with:
+
+* Mentor / onboarding buddy
+* Tech lead
+* Team members
+
+Know who to ask:
+
+* technical questions
+* process questions
+* emergency questions
+
+These are often different people.
+
+---
+
+## Read Core Documents
+
+Read at minimum:
+
+* employee_handbook.md
+* engineering_handbook.md
+* team_working_agreements.md
+* code_review_guidelines.md
+
+Skim is acceptable.
+Ignoring existence is not.
+
+---
+
+## Understand the Product
+
+Be able to answer at a high level:
+
+* What problem do we solve?
+* Who uses the product?
+* What systems matter most?
+
+Architecture details can come later.
+
+---
+
+# First Week
+
+## Development Setup Validation
+
+Complete:
+
+* Run application locally
+* Run tests
+* Make a tiny harmless code change
+* Open a practice pull request
+
+A ceremonial first PR is encouraged.
+
+---
+
+## First Safe Contributions
+
+Examples:
+
+* Fix typo or docs issue
+* Small bug fix
+* Add test
+* Improve internal notes
+
+Small wins reduce fear.
+
+---
+
+## Observe Team Rituals
+
+Attend and observe:
+
+* Standup/check-in
+* Planning
+* Review/demo
+* Retro (if scheduled)
+
+Understanding cadence matters.
+
+---
+
+## Learn Escalation Model
+
+Understand when to:
+
+🟢 Proceed yourself
+🟡 Ask teammate first
+🔴 Escalate lead
+
+This is part of engineering judgment.
+
+---
+
+# First 30 Days
+
+## Deliver One Meaningful Contribution
+
+Examples:
+
+* Ship small feature
+* Improve workflow
+* Contribute design doc
+* Improve test coverage
+
+Goal is contribution, not heroics.
+
+---
+
+## Learn Core Architecture
+
+Gain basic understanding of:
+
+* Main services
+* Data flow
+* Deploy path
+* Failure points
+
+Not every box in the diagram needs to be mysterious.
+
+---
+
+## Ask These Questions
+
+Recommended questions new joiners should ask:
+
+* What mistakes do newcomers often make?
+* What breaks most often?
+* What is under-documented?
+* How do strong contributors earn trust here?
+
+These often teach more than tutorials.
+
+---
+
+# Practical Setup Checklist
+
+## Git Hygiene
+
+* Configure name/email
+* Verify branch workflow
+* Learn PR template
+* Learn commit conventions
+
+---
+
+## Security Basics
+
+Verify you understand:
+
+* Secret handling
+* Access boundaries
+* Incident escalation path
+* AI-tool data restrictions
+
+---
+
+## Communication Setup
+
+Know:
+
+* Team channels
+* Support channels
+* Escalation channels
+* Incident channels (read-only if appropriate)
+
+Lurking is a legitimate onboarding technique.
+
+---
+
+# Rookie Traps To Avoid
+
+Do not:
+
+* Wait days before asking questions
+* Assume undocumented norms
+* Open giant first PRs
+* Pretend understanding when confused
+
+Confusion reported early is learning.
+Confusion hidden becomes risk.
+
+---
+
+# The First PR Tradition
+
+Unofficial tradition:
+
+Your first merged PR earns you the right to tell the story of how you accidentally broke local setup.
+
+Most people have one.
+
+Some have several.
+
+---
+
+# Optional Stretch Tasks
+
+If ahead of schedule:
+
+* Read one ADR
+* Review one old incident postmortem
+* Shadow one code review
+* Pair on one debugging session
+
+This accelerates tacit knowledge.
+
+---
+
+# Definition of Successful Onboarding
+
+By the end of onboarding you should:
+
+* Know how to ask for help
+* Be able to contribute safely
+* Understand basic workflows
+* Have merged something
+* Be less afraid of the codebase than day one
+
+That is success.
+
+---
+
+## Signoff Checklist
+
+* [ ] Access complete
+* [ ] Local setup works
+* [ ] First PR opened
+* [ ] First PR merged
+* [ ] Core docs read
+* [ ] Escalation model understood
+* [ ] Onboarding buddy check-in completed
+
+---
+
+**Related documents**
+
+* rookie_mistakes.md
+* when_to_ask_for_help.md
+* good_pull_request_example.md
+* past_onboarding_questions.md

--- a/src/rag/data/rookie_mistakes.md
+++ b/src/rag/data/rookie_mistakes.md
@@ -1,0 +1,83 @@
+# rookie_mistakes.md
+
+## Rookie Mistakes We See Often
+
+Common patterns:
+
+## 1. Staying stuck too long
+
+Trying alone for six hours is often not grit.
+It is latency.
+
+---
+
+## 2. Asking zero-context questions
+
+"It broke" is not a bug report.
+
+---
+
+## 3. Oversized first PRs
+
+Confidence does not scale with line count.
+
+---
+
+## 4. Mistaking silence for agreement
+
+No feedback does not imply approval.
+
+---
+
+## 5. Hiding uncertainty
+
+Experienced engineers usually surface uncertainty.
+They do not perform certainty.
+
+---
+
+## 6. Optimizing too early
+
+Make it work.
+Then improve.
+
+---
+
+## 7. Treating feedback as judgment
+
+Review comments are usually system-improvement attempts.
+
+---
+
+## 8. Escalating too late
+
+Classic failure mode.
+
+---
+
+## Rookie Heuristic
+
+If you are thinking:
+“I should probably ask…”
+You probably should.
+
+---
+
+## What Strong Interns Tend To Do
+
+* show reasoning
+* ask sharp questions
+* improve small things proactively
+* document what they learn
+
+Reliability compounds.
+
+---
+
+# Informal Rule
+
+Trying one thing twice is persistence.
+Trying the same failing thing eight times is ritual.
+
+Related:
+what_good_interns_do.md

--- a/src/rag/data/when_to_ask_for_help.md
+++ b/src/rag/data/when_to_ask_for_help.md
@@ -1,0 +1,92 @@
+# when_to_ask_for_help.md
+
+## When To Ask For Help
+
+# Default Guideline
+
+Try yourself first.
+Do not struggle theatrically.
+
+---
+
+Ask for help when:
+
+* Blocked 30–60 minutes without progress
+* Risk may be increasing
+* Requirements are unclear
+* Decision affects others
+
+---
+
+# Bring These When Asking
+
+Include:
+
+* What you tried
+* What you suspect
+* What confuses you
+* What help you need
+
+Questions improve with preparation.
+
+---
+
+# Good Reasons To Ask Early
+
+* Prevent rework
+* Reduce risk
+* Learn faster
+* Avoid local optimization traps
+
+---
+
+# When Not To Ask Immediately
+
+Do some initial effort first.
+
+Read docs.
+Check examples.
+Use your duck.
+
+---
+
+# Escalation Ladder
+
+1. Documentation
+2. Peer
+3. Mentor
+4. Lead escalation
+
+Use the smallest sufficient escalation.
+
+---
+
+# Anti-Patterns
+
+Avoid:
+
+* asking before thinking
+* asking after suffering silently for days
+* asking with no concrete question
+
+Both extremes fail.
+
+---
+
+# A Useful Test
+
+Before asking:
+Can I articulate the problem clearly?
+
+If not,
+clarify the problem first.
+
+---
+
+# Informal Principle
+
+Good engineers ask for help sooner than ego prefers.
+
+Related:
+communication_norms.md
+rookie_mistakes.md

--- a/src/rag/knowledge_base/adr_001_why_fastapi.md
+++ b/src/rag/knowledge_base/adr_001_why_fastapi.md
@@ -1,0 +1,61 @@
+# adr_001_why_fastapi.md
+
+## ADR-001 Why FastAPI
+
+Status: Accepted
+
+## Context
+
+Need API framework for agent endpoints and RAG service.
+
+---
+
+## Decision
+
+Use FastAPI.
+
+---
+
+## Reasons
+
+Chosen for:
+
+* Python-native fit
+* Pydantic validation
+* Async support
+* Good developer velocity
+* Strong ecosystem
+
+---
+
+## Tradeoffs Accepted
+
+* Not minimal as Flask
+* Some framework abstraction overhead
+* Async misuse can add complexity
+
+Accepted.
+
+---
+
+## Alternatives Considered
+
+Flask:
+Simpler, less structure.
+
+Django:
+Too heavy for current scope.
+
+---
+
+## Consequences
+
+API schemas become first-class.
+Validation shifts earlier.
+Good fit for agent interfaces.
+
+---
+
+## Informal Note
+
+We chose boring-good over novel-interesting.

--- a/src/rag/knowledge_base/adr_002_why_lancedb.md
+++ b/src/rag/knowledge_base/adr_002_why_lancedb.md
@@ -1,0 +1,59 @@
+# adr_002_why_lancedb.md
+
+## ADR-002 Why LanceDB
+
+Status: Accepted
+
+## Context
+
+Need vector store for RAG retrieval.
+
+---
+
+## Decision
+
+Use LanceDB.
+
+---
+
+## Reasons
+
+Selected for:
+
+* Good Python ergonomics
+* Local-first simplicity
+* Suitable for project scale
+* Vector + tabular model appealing
+* Easy experimentation
+
+---
+
+## Tradeoffs Accepted
+
+Not highest-scale option.
+Some production ecosystems more mature elsewhere.
+
+Accepted for current needs.
+
+---
+
+## Alternatives Considered
+
+FAISS:
+Strong, but less database-like workflow.
+
+Managed vector DB:
+Useful later, heavier now.
+
+---
+
+## Consequences
+
+Fast iteration favored.
+Can revisit later.
+
+---
+
+## Informal Note
+
+Optimize for learning leverage before hyperscale fantasies.

--- a/src/rag/knowledge_base/bad_pull_request_example.md
+++ b/src/rag/knowledge_base/bad_pull_request_example.md
@@ -1,0 +1,31 @@
+# bad_pull_request_example.md
+
+## Example of Problematic Pull Request
+
+Title:
+fixes and updates
+
+Description:
+Updated a bunch of things related to agents, retrieval, prompts, UI and deployment.
+
+Changed:
+
+* prompt logic
+* schemas
+* frontend layout
+* logging
+* deployment config
+
+Testing:
+Works locally.
+
+Problems:
+
+* scope too broad
+* no rationale
+* many concerns mixed
+* no risk discussion
+* impossible review surface
+
+Unofficial diagnosis:
+This is several PRs wearing a trench coat.

--- a/src/rag/knowledge_base/branching_and_git_workflow.md
+++ b/src/rag/knowledge_base/branching_and_git_workflow.md
@@ -1,0 +1,56 @@
+# branching_and_git_workflow.md
+
+## Branching and Git Workflow
+
+Default model:
+
+* main is protected
+* work happens in feature branches
+* changes land through pull requests
+
+---
+
+## Branch Naming
+
+Prefer:
+feature/...
+fix/...
+chore/...
+
+Examples:
+feature/seed-rag-knowledge-base
+fix/handle-tool-timeout
+
+Names should explain intent.
+
+---
+
+## Commit Guidance
+
+Prefer small atomic commits.
+
+Good:
+feat: add retrieval fallback handling
+
+Bad:
+stuff
+
+Commits are historical evidence.
+
+---
+
+## Rules
+
+* No direct commits to main
+* Rebase or merge per team convention
+* Keep branches short-lived
+* Avoid giant divergence
+
+Long-lived branches grow teeth.
+
+---
+
+## Informal Rule
+
+If resolving merge conflicts feels archaeological,
+branch lived too long.

--- a/src/rag/knowledge_base/code_review_guidelines.md
+++ b/src/rag/knowledge_base/code_review_guidelines.md
@@ -1,0 +1,324 @@
+# code_review_guidelines.md
+
+## Code Review Guidelines — 404 Brain Not Found
+
+**Version:** 0.1
+**Purpose:** Shared expectations for writing, reviewing and merging pull requests.
+
+---
+
+# Why We Review
+
+Code review exists to improve:
+
+* Correctness
+* Maintainability
+* Shared understanding
+* Risk detection
+* Learning
+
+It is not a ritual before merge.
+It is part of engineering.
+
+---
+
+# What Good Pull Requests Look Like
+
+Good PRs are usually:
+
+* Small enough to review in one sitting
+* Focused on one coherent change
+* Clear about intent
+* Honest about tradeoffs
+
+A reviewer should not need detective skills.
+
+---
+
+## A Good PR Description Includes
+
+* What changed
+* Why it changed
+* Risks or edge cases
+* Testing performed
+* Questions where feedback is wanted
+
+Template:
+
+## Summary
+
+Short explanation.
+
+## Why
+
+Problem addressed.
+
+## Testing
+
+What was validated.
+
+## Risks
+
+Known uncertainties.
+
+---
+
+# PR Size Guidance
+
+Rough preference:
+
+* Small: ideal
+* Medium: normal
+* Large: justify
+* Massive: probably should be split
+
+If someone needs snacks before reviewing your PR, it may be too large.
+
+---
+
+# Before Opening a PR
+
+Ask yourself:
+
+* Would I understand this PR cold?
+* Is scope too broad?
+* Are assumptions explained?
+* Did I update docs if needed?
+* Would I merge this if someone else wrote it?
+
+That last question catches things.
+
+---
+
+# What Reviewers Look For
+
+Reviewers commonly check:
+
+## Correctness
+
+* Does it work?
+* Are edge cases missed?
+* Can it fail dangerously?
+
+---
+
+## Design
+
+* Is complexity justified?
+* Is simpler possible?
+* Does it fit surrounding patterns?
+
+---
+
+## Maintainability
+
+* Can others support this later?
+* Is naming understandable?
+* Is hidden coupling introduced?
+
+---
+
+## Operational Risk
+
+* Logging impact?
+* Deployment implications?
+* Failure modes?
+
+---
+
+# Review Comments
+
+Common kinds of comments:
+
+**Blocking**
+Must resolve before merge.
+
+**Non-blocking suggestion**
+Improvement opportunity.
+
+**Question**
+Reviewer uncertainty.
+
+Treat these differently.
+
+Not every comment is a stop sign.
+
+---
+
+# How To Respond To Review Feedback
+
+Good responses:
+
+* Revise the code
+* Explain reasoning respectfully
+* Ask follow-ups
+* Disagree when justified, calmly
+
+"Fixed" is rarely a useful response by itself.
+
+---
+
+# What Review Is Not For
+
+Review is not for:
+
+* Personal criticism
+* Showing superiority
+* Rewriting everything to personal taste
+* Architecture ambushes unrelated to scope
+
+Do not smuggle redesigns into typo fixes.
+
+---
+
+# Approval Expectations
+
+Default:
+
+* At least one meaningful review
+* Higher-risk changes may require more
+* Author should not self-approve around safeguards
+
+Approval means:
+
+Reasonable confidence.
+Not perfection guarantee.
+
+---
+
+# When To Escalate Instead Of Merge
+
+Escalate if PR includes:
+
+* Security concerns
+* Data integrity risk
+* Architectural boundary changes
+* Unclear ownership conflicts
+
+Some PRs are decisions disguised as code.
+
+Those need discussion.
+
+---
+
+# Common Rookie PR Mistakes
+
+Frequent patterns:
+
+* PR too large
+* No context in description
+* Defensive response to feedback
+* Mixing many concerns in one branch
+* Opening PR only when "finished"
+
+Open earlier.
+
+Draft PRs exist for a reason.
+
+---
+
+# Common Reviewer Mistakes
+
+Also common:
+
+* Nitpicking style over substance
+* Vague comments
+* Drive-by approvals without reading
+* Turning review into ego theater
+
+"Looks good" on a 700-line PR is suspicious.
+
+---
+
+# Review Latency Norm
+
+Do not leave teammates waiting indefinitely.
+
+Review is part of delivery, not optional volunteer work.
+
+If overloaded:
+
+* acknowledge
+* set expectation
+* redirect if needed
+
+---
+
+# Special Guidance for AI/LLM Code
+
+Review additionally for:
+
+* Prompt behavior risks
+* Schema validation
+* Tool failure handling
+* Hallucination guardrails
+* Evaluation coverage
+
+Model output logic deserves skepticism.
+
+---
+
+# Merge Readiness Checklist
+
+Before merge:
+
+* [ ] Tests pass
+* [ ] Review comments addressed
+* [ ] Risks understood
+* [ ] Docs updated if needed
+* [ ] Rollback path known
+
+Then merge.
+Monitor.
+Breathe.
+
+---
+
+# Informal Review Principles
+
+## The Reviewer Is Not The Enemy
+
+Good reviewers reduce incidents.
+
+---
+
+## The Three-Question Rule
+
+Before major criticism, ask:
+
+* Is it wrong?
+* Is it risky?
+* Or is it just not how I would do it?
+
+Only the first two may justify blocking.
+
+---
+
+## The Friday Rule
+
+Deploy skepticism increases late Friday.
+
+This is rational.
+
+---
+
+# Example of a Strong Review Comment
+
+Weak:
+
+> This seems bad.
+
+Better:
+
+> I may be missing context, but this introduces retry logic without timeout bounds. Could this create runaway behavior under failure?
+
+Precision scales.
+
+---
+
+**Related documents**
+
+* good_pull_request_example.md
+* bad_pull_request_example.md
+* branching_and_git_workflow.md
+* rookie_mistakes.md

--- a/src/rag/knowledge_base/communication_norms.md
+++ b/src/rag/knowledge_base/communication_norms.md
@@ -1,0 +1,101 @@
+# communication_norms.md
+
+## Communication Norms — 404 Brain Not Found
+
+# Async First
+
+Default to asynchronous communication unless urgency demands otherwise.
+
+Bring:
+
+* context
+* concrete question
+* what you tried
+
+---
+
+# When To Ping
+
+Ping teammates for:
+
+* blockers
+* dependencies
+* time-sensitive clarification
+
+Do not use “quick question?” as a standalone message.
+Ask the question.
+
+---
+
+# Escalation Messaging
+
+Good:
+“Deploy failing after config change, logs suggest secret mismatch. Can someone sanity-check?”
+
+Bad:
+“Help.”
+
+---
+
+# Response Expectations
+
+Not every chat message is urgent.
+Respect focus.
+
+Urgent should mean urgent.
+
+---
+
+# Meetings
+
+Come with:
+
+* context
+* decisions needed
+* risks surfaced
+
+Meetings are expensive.
+Use intentionally.
+
+---
+
+# Written Communication Principle
+
+Optimize for messages readable without extra explanation.
+
+Future readers exist.
+
+---
+
+# Ask In Public By Default
+
+Use public channels unless privacy requires otherwise.
+
+Private DMs hide reusable answers.
+
+---
+
+# The Two-Bounce Rule
+
+If a chat thread exceeds two clarification bounces,
+consider a call.
+
+---
+
+# Anti-Patterns
+
+Avoid:
+
+* vague urgency
+* hidden blockers
+* passive-aggressive ambiguity
+* weaponized silence
+
+---
+
+# Informal Principle
+
+Ping people like you would want to be pinged.
+
+Related:
+when_to_ask_for_help.md

--- a/src/rag/knowledge_base/deployment_runbook.md
+++ b/src/rag/knowledge_base/deployment_runbook.md
@@ -1,0 +1,49 @@
+# deployment_runbook.md
+
+## Deployment Runbook
+
+# Before Deploy
+
+Verify:
+
+* tests green
+* config reviewed
+* rollback path known
+* monitoring available
+
+---
+
+## Deploy Sequence
+
+1. Announce if needed
+2. Deploy
+3. Verify health
+4. Check logs/metrics
+5. Watch for regressions
+
+Deploy is not finished at step 2.
+
+---
+
+## If Things Go Wrong
+
+* Stabilize
+* Roll back if needed
+* Escalate early
+* Capture facts
+
+Do not improvise heroically.
+
+---
+
+## The Calm Rule
+
+Move deliberately.
+Fast panic is slower than calm action.
+
+---
+
+## Friday Rule
+
+Be extra skeptical of risky Friday deploys.
+The rule exists because history exists.

--- a/src/rag/knowledge_base/employee_handbook.md
+++ b/src/rag/knowledge_base/employee_handbook.md
@@ -1,0 +1,583 @@
+# employee_handbook.md
+
+## Employee Handbook — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Interns, junior engineers, and new team members
+**Purpose:** Provide a lightweight but realistic internal handbook for onboarding and daily collaboration.
+
+---
+
+# Welcome
+
+Welcome to **404 Brain Not Found**.
+
+We build practical AI systems with a bias toward experimentation, reliability, and thoughtful engineering.
+
+As a small technical organization, we expect everyone — including interns — to contribute meaningfully, ask questions early, and improve systems as they learn.
+
+This handbook explains how we work, what we expect, and how to navigate the organization.
+
+---
+
+# Our Principles
+
+We try to optimize for:
+
+1. **Clarity over complexity**
+   Prefer understandable systems over clever ones.
+
+2. **Ship small, improve often**
+   Iteration beats overdesign.
+
+3. **Evidence over opinion**
+   Use data, experiments and reasoning.
+
+4. **Escalate risks early**
+   Bad surprises are worse than early warnings.
+
+5. **Documentation is part of the work**
+   If it is not documented, it probably does not scale.
+
+---
+
+# Team Roles
+
+## Intern / Junior Engineer
+
+Expected to:
+
+* Complete onboarding tasks
+* Ask questions when blocked
+* Contribute code, documentation or analysis
+* Participate in reviews
+* Surface uncertainty early
+* Learn team norms and workflows
+
+You are not expected to know everything.
+You are expected to reason, communicate and learn.
+
+---
+
+## Engineer
+
+Responsible for:
+
+* Delivery and implementation
+* Code reviews
+* Technical guidance
+* Maintaining quality standards
+* Supporting onboarding
+
+---
+
+## Tech Lead
+
+Responsible for:
+
+* Architecture decisions
+* Technical prioritization
+* Risk escalation
+* Mentoring
+* Final approval for major changes
+
+---
+
+# How We Work
+
+## Default Work Pattern
+
+Most work follows:
+
+* Ticket or task definition
+* Clarify requirements
+* Implement in small increments
+* Open pull request early
+* Iterate through feedback
+* Merge when approved
+
+Work in visible increments.
+Avoid long-lived hidden work.
+
+---
+
+## Ownership
+
+If you pick up a task, you own:
+
+* Understanding the problem
+* Communicating blockers
+* Asking for help when needed
+* Leaving the work in a better state
+
+Ownership does not mean solving everything alone.
+
+---
+
+# Communication Channels
+
+## Chat (Slack/Teams)
+
+Used for:
+
+* Quick questions
+* Coordination
+* Async updates
+* Lightweight discussions
+
+Good messages include:
+
+* Context
+* What you tried
+* Specific ask
+
+Example:
+
+Bad:
+
+> Deploy broken, help.
+
+Better:
+
+> Staging deploy failed after config change. Checked logs and rollback notes, suspect env variable mismatch. Can someone sanity-check?
+
+---
+
+## Meetings
+
+Recurring meetings may include:
+
+* Daily check-in
+* Planning
+* Demo/review
+* Retrospective
+
+Come prepared.
+Short meetings should stay short.
+
+---
+
+## Documentation
+
+Use documentation for:
+
+* Decisions
+* Runbooks
+* Architecture notes
+* Repeated questions
+
+Don’t bury operational knowledge in chat threads.
+
+---
+
+# Expectations for New Team Members
+
+## First 30 Days
+
+You should aim to:
+
+* Understand system basics
+* Ship at least one small contribution
+* Participate in a code review
+* Learn escalation paths
+* Become productive in core tools
+
+Progress matters more than speed.
+
+---
+
+## Asking Questions
+
+Ask early when:
+
+* You are blocked more than ~30–60 minutes
+* You might introduce risk
+* Requirements are ambiguous
+* A decision affects others
+
+Before asking:
+
+1. Read relevant documentation
+2. Try a reasonable approach
+3. Bring your reasoning with the question
+
+---
+
+# Feedback Culture
+
+Feedback is expected.
+
+Review feedback critiques work, not people.
+
+Good responses to feedback:
+
+* Ask clarifying questions
+* Revise thoughtfully
+* Challenge respectfully if needed
+
+Defensiveness slows learning.
+
+---
+
+# Escalation Guidance
+
+Use this model:
+
+## Proceed Yourself (Green)
+
+Examples:
+
+* Small refactors
+* Documentation improvements
+* Minor bug fixes
+* Non-risky experiments
+
+---
+
+## Ask Teammate First (Yellow)
+
+Examples:
+
+* Unclear design choices
+* Shared code ownership areas
+* Changes affecting interfaces
+* Suspicious test failures
+
+---
+
+## Escalate to Lead (Red)
+
+Examples:
+
+* Security concerns
+* Production risks
+* Incident indicators
+* Architectural changes
+* Data integrity uncertainty
+
+Escalating early is considered good judgment.
+
+---
+
+# Working Agreements
+
+We generally prefer:
+
+* Small PRs over massive PRs
+* Explicit assumptions over hidden assumptions
+* Reproducible fixes over manual heroics
+* Calm incident handling over improvisation
+
+Avoid:
+
+* Silent blockers
+* Scope creep without discussion
+* “Works on my machine” handoffs
+* Merging unreviewed risky code
+
+---
+
+# Time and Availability
+
+Respect focus time.
+
+Not every message requires immediate response.
+
+Use urgency intentionally.
+
+If something is urgent, say why.
+
+---
+
+# Tooling Expectations
+
+You are expected to learn and use:
+
+* Git and pull requests
+* Issue tracking
+* Local development setup
+* Testing basics
+* Documentation conventions
+
+Advanced expertise is not assumed on day one.
+
+---
+
+# What Good Interns Tend To Do
+
+Patterns we often value:
+
+* Ask thoughtful questions
+* Document what they learn
+* Improve small things proactively
+* Accept feedback quickly
+* Surface risks early
+* Leave breadcrumbs for others
+
+Signal reliability before trying to signal brilliance.
+
+---
+
+# Common Anti-Patterns
+
+Watch for these:
+
+* Waiting too long before asking for help
+* Overengineering simple tasks
+* Treating review comments as personal criticism
+* Solving symptoms instead of root causes
+* Assuming undocumented norms
+
+These are common, fixable mistakes.
+
+---
+
+# Decision Making
+
+Many decisions are reversible.
+
+For reversible decisions:
+
+* decide fast
+* test
+* adjust
+
+For hard-to-reverse decisions:
+
+* slow down
+* gather evidence
+* involve others
+
+---
+
+# Security and Confidentiality
+
+Basic rules:
+
+* Never commit secrets
+* Use approved access paths
+* Ask before using production data
+* Report accidental exposure immediately
+
+Security mistakes hidden become incidents.
+
+---
+
+# When Unsure
+
+Default sequence:
+
+1. Check documentation
+2. Check examples
+3. Ask teammate
+4. Escalate if risk exists
+
+Do not stay stuck alone.
+
+---
+
+# Employment Basics
+
+## Working Hours
+
+Standard expectation is roughly 40 hours per week.
+
+Core collaboration hours are normally:
+
+* 09:00–15:00 available for meetings and collaboration
+* Flexible time outside this is common
+
+We optimize for outcomes, not performative online presence.
+
+---
+
+## Remote and Hybrid Work
+
+Hybrid work is normal.
+
+Default expectation:
+
+* Be reachable during core hours
+* Keep calendars updated
+* Communicate when working asynchronously
+
+Remote does not mean invisible.
+
+---
+
+## Lunch and Breaks
+
+Take lunch.
+
+Recommended lunch break:
+
+* 45–60 minutes
+
+Short breaks are normal and encouraged.
+
+We strongly encourage food before making production decisions.
+
+Historical evidence supports this.
+
+---
+
+## Sick Leave
+
+If sick:
+
+* Notify your team lead or team channel early
+* Do not work through illness unless genuinely optional and light
+* Recovery outranks performative availability
+
+---
+
+## Vacation
+
+Vacation should be coordinated early and documented.
+
+Avoid disappearing with sole ownership of critical work.
+
+If only one person understands a system before vacation, that is a systems problem.
+
+---
+
+# Office Conduct
+
+## Shared Spaces
+
+Leave shared spaces usable.
+
+This includes:
+
+* Clean up after meals
+* Label food if storing it
+* Do not occupy meeting rooms as private offices all day
+
+If you make the last coffee and do not start a new pot, consequences may be mostly social.
+
+---
+
+## Smoking and Vaping
+
+Only in designated areas.
+
+Never near entrances, ventilation or outdoor collaboration areas.
+
+---
+
+## Noise and Focus
+
+Use judgment with interruptions.
+
+When someone is visibly in deep focus, prefer async questions unless urgent.
+
+---
+
+## Office Cat Policy
+
+If the office cat occupies your chair, that chair may be considered temporarily reassigned.
+
+---
+
+# Information Handling
+
+## Information Classification
+
+We use four practical classes:
+
+### Public
+
+Safe to share externally.
+
+### Internal
+
+Default internal material.
+
+### Confidential
+
+Restricted to relevant teams.
+
+### Restricted
+
+Sensitive systems, credentials, incident data or regulated information.
+
+When unsure, classify upward.
+
+---
+
+## AI Tool Usage
+
+Do not paste confidential or restricted data into external AI systems unless explicitly approved.
+
+Questions about this should be escalated.
+
+---
+
+# Acceptable Security Practices
+
+Expected:
+
+* Lock devices when away
+* Use approved password management
+* Never share credentials
+* Never commit secrets
+* Use least privilege access
+
+Security incidents hidden tend to grow.
+
+---
+
+# Benefits and Team Culture
+
+Typical cultural norms may include:
+
+* Team lunches
+* Demo Fridays
+* Learning sessions
+* Pairing hours
+* Conference or study budget where applicable
+
+First Friday demo failures are considered a rite of passage.
+
+---
+
+# Informal Internal Principles
+
+## The Two-Coffee Rule
+
+Do not escalate architecture debates before at least two people have had coffee.
+
+---
+
+## The Rubber Duck Clause
+
+Before interrupting a senior engineer, explain the problem once to a duck, plant or empty terminal.
+
+---
+
+## The 404 Principle
+
+Confusion is not failure.
+
+It is a documented state.
+
+---
+
+# Final Note
+
+We do not expect perfect decisions.
+
+We expect thoughtful decisions, visible reasoning and steady improvement.
+
+That is how people grow here.
+
+---
+
+**Related documents:**
+
+* onboarding_checklist.md
+* engineering_handbook.md
+* code_review_guidelines.md
+* incident_escalation_policy.md
+* rookie_mistakes.md
+* what_good_interns_do.md

--- a/src/rag/knowledge_base/engineering_handbook.md
+++ b/src/rag/knowledge_base/engineering_handbook.md
@@ -1,0 +1,291 @@
+# engineering_handbook.md
+
+## Engineering Handbook — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Engineers, interns, technical contributors
+
+---
+
+# Purpose
+
+This handbook describes how we build software.
+
+Employee handbook explains how we work together.
+This document explains how we engineer.
+
+---
+
+# Engineering Philosophy
+
+We generally prefer:
+
+* Simple systems over impressive systems
+* Observable systems over opaque systems
+* Small changes over heroic rewrites
+* Reliable boring solutions over fragile cleverness
+
+Default question:
+
+Can we make this simpler?
+
+---
+
+# Typical Development Flow
+
+Most work follows:
+
+1. Pick up ticket
+2. Clarify scope
+3. Sketch approach
+4. Implement small increments
+5. Open PR early
+6. Review and revise
+7. Merge and monitor
+
+Merge is not the end of work.
+Production behavior matters.
+
+---
+
+# Definition of Done
+
+Work is generally done when:
+
+* Requirements addressed
+* Tests pass
+* Edge cases considered
+* Documentation updated
+* Review completed
+* Monitoring implications considered
+
+"It runs locally" is not definition of done.
+
+---
+
+# Code Principles
+
+## Readability
+
+Code is written for future humans.
+
+Including tired future-you.
+
+---
+
+## Prefer Explicitness
+
+Hidden magic ages badly.
+
+Prefer:
+
+* Clear names
+* Small functions
+* Predictable interfaces
+* Visible error handling
+
+---
+
+## Comments
+
+Comment why.
+Not what obvious code does.
+
+---
+
+# Testing Expectations
+
+Reasonable expectations:
+
+* Unit tests for logic
+* Integration tests for flows
+* Manual validation for risky changes
+
+No one expects exhaustive tests for every prototype.
+
+But zero testing should feel suspicious.
+
+---
+
+# Git and Branching
+
+Typical model:
+
+* Feature branches
+* Pull requests for changes
+* Small atomic commits preferred
+
+Commit messages should help archaeology.
+
+Future debugging is time travel.
+Leave clues.
+
+---
+
+# Pull Requests
+
+Good PRs tend to:
+
+* Solve one coherent thing
+* Explain why change exists
+* Note risks or tradeoffs
+* Stay reviewable in size
+
+Large mysterious PRs are called novels.
+
+Novels are rarely merged happily.
+
+---
+
+# Code Review Norms
+
+Review looks for:
+
+* Correctness
+* Maintainability
+* Risk
+* Simplicity
+* Learning opportunities
+
+Review is collaboration, not border control.
+
+---
+
+# Error Handling
+
+Prefer:
+
+* Fail clearly
+* Log useful context
+* Degrade gracefully where possible
+* Use fallback behavior intentionally
+
+Silent failure is usually just delayed failure.
+
+---
+
+# Observability
+
+Think about:
+
+* Logs
+* Metrics
+* Traces
+* Alerts
+
+If a system breaks and no one can tell why, monitoring is incomplete.
+
+---
+
+# Deployments
+
+Normal principles:
+
+* Small changes safer than giant releases
+* Use checklists
+* Have rollback path
+* Never assume deployment succeeded
+
+Trust, then verify.
+
+---
+
+# Working with AI Systems
+
+For LLM and retrieval systems, additionally consider:
+
+* Grounding
+* Evaluation
+* Prompt behavior
+* Fallbacks
+* Hallucination risk
+* Tool failure modes
+
+Model output is input requiring scrutiny.
+
+---
+
+# Escalation in Engineering Decisions
+
+Proceed yourself:
+
+* Refactors
+* Small improvements
+* Documentation fixes
+
+Ask teammate:
+
+* Interface changes
+* Design uncertainty
+* Shared ownership code
+
+Escalate lead:
+
+* Security risk
+* Architecture shifts
+* Production instability
+
+---
+
+# Engineering Anti-Patterns
+
+Watch for:
+
+* Premature abstraction
+* Overengineering
+* Cargo-cult patterns
+* Hidden coupling
+* Copy-paste architecture
+
+And the classic:
+
+"We’ll clean it up later."
+
+History suggests otherwise.
+
+---
+
+# Design Biases We Prefer
+
+When tradeoffs are close, bias toward:
+
+* Maintainability
+* Reversibility
+* Operational simplicity
+* Clear ownership
+
+Elegant systems that no one can operate are not wins.
+
+---
+
+# The Carbon–Silicon Principle
+
+Humans make judgment.
+Systems provide leverage.
+
+Good engineering augments people.
+It does not hide reasoning from them.
+
+---
+
+# Informal Engineering Commandments
+
+1. Do not deploy on vibes.
+
+2. Read the error before rewriting the system.
+
+3. If three people debug manually, automate it.
+
+4. If everyone fears touching code, the code owns you.
+
+5. There shall be no unhandled exceptions left behind.
+
+---
+
+**Related documents**
+
+* code_review_guidelines.md
+* branching_and_git_workflow.md
+* deployment_runbook.md
+* adr_001_why_fastapi.md
+* adr_004_error_handling_strategy.md

--- a/src/rag/knowledge_base/example_design_doc.md
+++ b/src/rag/knowledge_base/example_design_doc.md
@@ -1,0 +1,36 @@
+# example_design_doc.md
+
+## Mini Design Spec Example
+
+Problem:
+Interns repeatedly ask similar onboarding questions.
+
+Proposal:
+Add retrieval-backed onboarding assistant with escalation guidance.
+
+Scope:
+
+* answer questions over knowledge base
+* provide escalation suggestions
+* log unanswered questions
+
+Out of scope:
+
+* autonomous task execution
+* ticket creation
+
+Risks:
+
+* weak retrieval relevance
+* hallucination risk
+* stale documentation
+
+Mitigations:
+
+* evaluation
+* fallback responses
+* document ownership
+
+Decision note:
+Start narrow.
+Expand after evidence.

--- a/src/rag/knowledge_base/example_incident_postmortem.md
+++ b/src/rag/knowledge_base/example_incident_postmortem.md
@@ -1,0 +1,31 @@
+# example_incident_postmortem.md
+
+## Incident Postmortem Example
+
+Incident:
+RAG assistant returned stale architectural guidance after outdated chunks dominated retrieval.
+
+Impact:
+Incorrect guidance shown internally.
+No customer harm.
+
+Root Cause:
+Chunk refresh pipeline had silently failed.
+
+Contributing Factors:
+
+* missing freshness checks
+* weak monitoring
+* overconfidence in retrieval quality
+
+Resolution:
+
+* fixed ingest job
+* added freshness metadata
+* added retrieval evaluation checks
+
+Lessons:
+Retrieval quality is an operational concern, not only model concern.
+
+Blameless Note:
+Failure emerged from system gaps, not individual negligence.

--- a/src/rag/knowledge_base/good_pull_request_example.md
+++ b/src/rag/knowledge_base/good_pull_request_example.md
@@ -1,0 +1,31 @@
+# good_pull_request_example.md
+
+## Example of Strong Pull Request
+
+Title:
+feat: add fallback response when retrieval returns no context
+
+Summary:
+Adds guarded fallback behavior so assistant returns uncertainty response rather than hallucinated answer when retrieval yields empty results.
+
+Why:
+Observed failure mode during testing.
+
+Testing:
+
+* unit test added
+* empty-context scenario tested
+* regression check passed
+
+Risks:
+Minimal, touches response routing only.
+
+Why this is good:
+
+* focused scope
+* explains intent
+* documents risk
+* includes validation
+
+Reviewer note:
+Good example of small, reviewable change.

--- a/src/rag/knowledge_base/incident_escalation_policy.md
+++ b/src/rag/knowledge_base/incident_escalation_policy.md
@@ -1,0 +1,145 @@
+# incident_escalation_policy.md
+
+## Incident Escalation Policy — 404 Brain Not Found
+
+**Version:** 0.1
+
+# Purpose
+
+Defines when and how operational or security incidents should be escalated.
+
+---
+
+# Severity Levels
+
+## Sev 4 — Minor
+
+Low impact.
+Localized issue.
+No customer harm.
+
+Examples:
+
+* Noncritical bug
+* Internal tool degraded
+* Single-user issue
+
+Default: solve in team.
+
+---
+
+## Sev 3 — Moderate
+
+Customer-facing degradation.
+Limited impact.
+
+Examples:
+
+* Partial service outage
+* Repeated failed deploys
+* Retrieval quality collapse in production
+
+Escalate to responsible engineer.
+
+---
+
+## Sev 2 — Major
+
+Significant customer or business impact.
+
+Examples:
+
+* Production instability
+* Data corruption risk
+* Security anomaly
+* Failed rollback
+
+Escalate immediately.
+
+---
+
+## Sev 1 — Critical
+
+Company-threatening event.
+
+Examples:
+
+* Major outage
+* Credential compromise
+* Sensitive data exposure
+* Autonomous model action causing harm
+
+Wake people up.
+
+---
+
+# Escalation Rules
+
+Escalate early if:
+
+* Unsure of severity
+* Blast radius unknown
+* Security may be involved
+* You think “maybe this is serious”
+
+That thought is often the escalation trigger.
+
+---
+
+# Incident Principles
+
+1. Stabilize before optimize.
+2. Contain before explain.
+3. Facts before theories.
+4. No blame during active incident.
+
+---
+
+# What To Include In Escalation
+
+Provide:
+
+* What happened
+* Current impact
+* What you observed
+* What you already tried
+* What risk worries you
+
+Good escalation reduces chaos.
+
+---
+
+# Things You Never Wait On
+
+Immediately escalate:
+
+* Possible secrets leak
+* Customer data exposure
+* Production deletion risk
+* Suspicious model/tool behavior
+
+Minutes matter.
+
+---
+
+# Rookie Rule
+
+When unsure whether to escalate:
+Escalate.
+
+False-positive escalation is usually cheaper than missed incidents.
+
+---
+
+# Informal Law
+
+If someone says
+“this is probably fine”
+during an incident,
+verify.
+
+---
+
+Related:
+example_incident_postmortem.md
+incident_lessons_learned.md

--- a/src/rag/knowledge_base/onboarding_checklist.md
+++ b/src/rag/knowledge_base/onboarding_checklist.md
@@ -1,0 +1,294 @@
+# onboarding_checklist.md
+
+## New Joiner Onboarding Checklist — 404 Brain Not Found
+
+**Version:** 0.1
+**Audience:** Interns and junior engineers
+**Purpose:** First-week and first-30-day onboarding guide.
+
+---
+
+# Before Day One
+
+## Access and Accounts
+
+Confirm access to:
+
+* Company email
+* Chat (Slack/Teams)
+* GitHub organization
+* Issue tracker
+* Documentation/wiki
+* Cloud/dev environments
+* Password manager / secrets access (if approved)
+
+If something is missing, raise it early.
+
+Day one should not begin with credential archaeology.
+
+---
+
+## Hardware Setup
+
+Verify:
+
+* Laptop provisioned
+* Required software installed
+* VPN (if needed)
+* SSH keys configured
+* Development environment tested
+
+Success criterion:
+
+Clone repo.
+Run something.
+Break nothing.
+
+---
+
+# Day One
+
+## Meet the Team
+
+Complete introductions with:
+
+* Mentor / onboarding buddy
+* Tech lead
+* Team members
+
+Know who to ask:
+
+* technical questions
+* process questions
+* emergency questions
+
+These are often different people.
+
+---
+
+## Read Core Documents
+
+Read at minimum:
+
+* employee_handbook.md
+* engineering_handbook.md
+* team_working_agreements.md
+* code_review_guidelines.md
+
+Skim is acceptable.
+Ignoring existence is not.
+
+---
+
+## Understand the Product
+
+Be able to answer at a high level:
+
+* What problem do we solve?
+* Who uses the product?
+* What systems matter most?
+
+Architecture details can come later.
+
+---
+
+# First Week
+
+## Development Setup Validation
+
+Complete:
+
+* Run application locally
+* Run tests
+* Make a tiny harmless code change
+* Open a practice pull request
+
+A ceremonial first PR is encouraged.
+
+---
+
+## First Safe Contributions
+
+Examples:
+
+* Fix typo or docs issue
+* Small bug fix
+* Add test
+* Improve internal notes
+
+Small wins reduce fear.
+
+---
+
+## Observe Team Rituals
+
+Attend and observe:
+
+* Standup/check-in
+* Planning
+* Review/demo
+* Retro (if scheduled)
+
+Understanding cadence matters.
+
+---
+
+## Learn Escalation Model
+
+Understand when to:
+
+🟢 Proceed yourself
+🟡 Ask teammate first
+🔴 Escalate lead
+
+This is part of engineering judgment.
+
+---
+
+# First 30 Days
+
+## Deliver One Meaningful Contribution
+
+Examples:
+
+* Ship small feature
+* Improve workflow
+* Contribute design doc
+* Improve test coverage
+
+Goal is contribution, not heroics.
+
+---
+
+## Learn Core Architecture
+
+Gain basic understanding of:
+
+* Main services
+* Data flow
+* Deploy path
+* Failure points
+
+Not every box in the diagram needs to be mysterious.
+
+---
+
+## Ask These Questions
+
+Recommended questions new joiners should ask:
+
+* What mistakes do newcomers often make?
+* What breaks most often?
+* What is under-documented?
+* How do strong contributors earn trust here?
+
+These often teach more than tutorials.
+
+---
+
+# Practical Setup Checklist
+
+## Git Hygiene
+
+* Configure name/email
+* Verify branch workflow
+* Learn PR template
+* Learn commit conventions
+
+---
+
+## Security Basics
+
+Verify you understand:
+
+* Secret handling
+* Access boundaries
+* Incident escalation path
+* AI-tool data restrictions
+
+---
+
+## Communication Setup
+
+Know:
+
+* Team channels
+* Support channels
+* Escalation channels
+* Incident channels (read-only if appropriate)
+
+Lurking is a legitimate onboarding technique.
+
+---
+
+# Rookie Traps To Avoid
+
+Do not:
+
+* Wait days before asking questions
+* Assume undocumented norms
+* Open giant first PRs
+* Pretend understanding when confused
+
+Confusion reported early is learning.
+Confusion hidden becomes risk.
+
+---
+
+# The First PR Tradition
+
+Unofficial tradition:
+
+Your first merged PR earns you the right to tell the story of how you accidentally broke local setup.
+
+Most people have one.
+
+Some have several.
+
+---
+
+# Optional Stretch Tasks
+
+If ahead of schedule:
+
+* Read one ADR
+* Review one old incident postmortem
+* Shadow one code review
+* Pair on one debugging session
+
+This accelerates tacit knowledge.
+
+---
+
+# Definition of Successful Onboarding
+
+By the end of onboarding you should:
+
+* Know how to ask for help
+* Be able to contribute safely
+* Understand basic workflows
+* Have merged something
+* Be less afraid of the codebase than day one
+
+That is success.
+
+---
+
+## Signoff Checklist
+
+* [ ] Access complete
+* [ ] Local setup works
+* [ ] First PR opened
+* [ ] First PR merged
+* [ ] Core docs read
+* [ ] Escalation model understood
+* [ ] Onboarding buddy check-in completed
+
+---
+
+**Related documents**
+
+* rookie_mistakes.md
+* when_to_ask_for_help.md
+* good_pull_request_example.md
+* past_onboarding_questions.md

--- a/src/rag/knowledge_base/rookie_mistakes.md
+++ b/src/rag/knowledge_base/rookie_mistakes.md
@@ -1,0 +1,83 @@
+# rookie_mistakes.md
+
+## Rookie Mistakes We See Often
+
+Common patterns:
+
+## 1. Staying stuck too long
+
+Trying alone for six hours is often not grit.
+It is latency.
+
+---
+
+## 2. Asking zero-context questions
+
+"It broke" is not a bug report.
+
+---
+
+## 3. Oversized first PRs
+
+Confidence does not scale with line count.
+
+---
+
+## 4. Mistaking silence for agreement
+
+No feedback does not imply approval.
+
+---
+
+## 5. Hiding uncertainty
+
+Experienced engineers usually surface uncertainty.
+They do not perform certainty.
+
+---
+
+## 6. Optimizing too early
+
+Make it work.
+Then improve.
+
+---
+
+## 7. Treating feedback as judgment
+
+Review comments are usually system-improvement attempts.
+
+---
+
+## 8. Escalating too late
+
+Classic failure mode.
+
+---
+
+## Rookie Heuristic
+
+If you are thinking:
+“I should probably ask…”
+You probably should.
+
+---
+
+## What Strong Interns Tend To Do
+
+* show reasoning
+* ask sharp questions
+* improve small things proactively
+* document what they learn
+
+Reliability compounds.
+
+---
+
+# Informal Rule
+
+Trying one thing twice is persistence.
+Trying the same failing thing eight times is ritual.
+
+Related:
+what_good_interns_do.md

--- a/src/rag/knowledge_base/when_to_ask_for_help.md
+++ b/src/rag/knowledge_base/when_to_ask_for_help.md
@@ -1,0 +1,92 @@
+# when_to_ask_for_help.md
+
+## When To Ask For Help
+
+# Default Guideline
+
+Try yourself first.
+Do not struggle theatrically.
+
+---
+
+Ask for help when:
+
+* Blocked 30–60 minutes without progress
+* Risk may be increasing
+* Requirements are unclear
+* Decision affects others
+
+---
+
+# Bring These When Asking
+
+Include:
+
+* What you tried
+* What you suspect
+* What confuses you
+* What help you need
+
+Questions improve with preparation.
+
+---
+
+# Good Reasons To Ask Early
+
+* Prevent rework
+* Reduce risk
+* Learn faster
+* Avoid local optimization traps
+
+---
+
+# When Not To Ask Immediately
+
+Do some initial effort first.
+
+Read docs.
+Check examples.
+Use your duck.
+
+---
+
+# Escalation Ladder
+
+1. Documentation
+2. Peer
+3. Mentor
+4. Lead escalation
+
+Use the smallest sufficient escalation.
+
+---
+
+# Anti-Patterns
+
+Avoid:
+
+* asking before thinking
+* asking after suffering silently for days
+* asking with no concrete question
+
+Both extremes fail.
+
+---
+
+# A Useful Test
+
+Before asking:
+Can I articulate the problem clearly?
+
+If not,
+clarify the problem first.
+
+---
+
+# Informal Principle
+
+Good engineers ask for help sooner than ego prefers.
+
+Related:
+communication_norms.md
+rookie_mistakes.md


### PR DESCRIPTION
Adds initial seed documents for the Wired Al RAG knowledge base.

Includes example source material for:
- onboarding and employee guidance
- engineering practices and code review
- architectural decision records (ADRs)
- deployment and escalation procedures
- cultural and tacit knowledge (rookie mistakes, when to ask for help)

Purpose:
Provide an initial retrieval corpus for later LanceDB ingestion and RAG integration.

Implementation of ingestion and retrieval will come in separate PRs.