### PR TITLE
feat(agent): inject retrieval context into chat flow

### DIFF
--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -1,9 +1,9 @@
 from dotenv import load_dotenv
 from pydantic_ai import Agent
 
-from backend.prompts import SYSTEM_PROMPT
+from backend.prompts import SYSTEM_PROMPT, RAG_PROMPT_TEMPLATE
 from backend.constants import MODEL_MEDIUM
-from backend.schemas import ChatResponse
+from backend.schemas import ChatResponse, SourceDocument
 
 from rag.retrieval import retrieve_documents
 
@@ -15,8 +15,28 @@ wired_al_agent = Agent(
 
 
 async def chat(question: str) -> ChatResponse:
-    result = await wired_al_agent.run(question)
-    return result.output
+    documents = retrieve_documents(question)
+
+    context = "\n\n".join(
+        f"Document: {doc['document_name']}\nContent:\n{doc['content']}"
+        for doc in documents
+    )
+
+    prompt = RAG_PROMPT_TEMPLATE.format(question=question, context=context)
+
+    result = await wired_al_agent.run(prompt)
+
+    return ChatResponse(
+        answer=result.output.answer,
+        sources=[
+            SourceDocument(
+                document_name=doc["document_name"],
+                file_path=doc["file_path"],
+                content_preview=(doc.get("content") or "")[:200],
+            )
+            for doc in documents
+        ],
+    )
 
 
 @wired_al_agent.tool_plain

--- a/packages/backend/src/backend/prompts.py
+++ b/packages/backend/src/backend/prompts.py
@@ -42,3 +42,15 @@ Return:
 </output>
 
 """
+
+RAG_PROMPT_TEMPLATE = """
+User question:
+{question}
+
+Retrieved documentation:
+{context}
+
+Answer using retrieved documentation only.
+If insufficient evidence exists, say so.
+Return sources.
+"""

--- a/packages/rag/src/rag/retrieval.py
+++ b/packages/rag/src/rag/retrieval.py
@@ -1,11 +1,11 @@
 import lancedb
-from backend.constants import VECTOR_DB_PATH
+from backend.constants import VECTOR_DB_PATH, TABLE_NAME
 
 db = lancedb.connect(VECTOR_DB_PATH)
 
 
 def retrieve_documents(query: str, k: int = 3):
-    results = db["articles"].search(query).limit(k).to_list()
+    results = db[TABLE_NAME].search(query).limit(k).to_list()
     return [
         {
             "document_name": result["document_name"],


### PR DESCRIPTION
## Summary
Adds explicit retrieval context injection to the chat flow instead of relying on implicit tool calling.

## Changes
- inject retrieved documents before generation
- move RAG prompt template into prompts.py
- populate sources from retrieval results
- use TABLE_NAME constant in retrieval

## Why
Improves grounding, makes agent behavior more deterministic, and reduces hallucinated sources.