### PR TITLE
chore(git): ignore lancedb artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,5 +208,5 @@ __marimo__/
 
 .DS_Store
 
-
-/src/rag/knowledge_base/articles.lance
+packages/rag/knowledge_base/*
+!packages/rag/knowledge_base/.gitkeep


### PR DESCRIPTION
## Summary
Ignore generated LanceDB artifacts while keeping the knowledge_base directory structure in the repo.

## Changes
- add LanceDB artifacts to .gitignore
- keep directory with .gitkeep