### PR TITLE
feat(evaluation): scaffold baseline eval dataset

### DIFF
--- a/packages/evaluation/data/eval_cases.json
+++ b/packages/evaluation/data/eval_cases.json
@@ -1,0 +1,78 @@
+[
+    {
+        "inputs": {
+            "question": "How do code reviews work here?"
+        },
+        "expectations": {
+            "expected_facts": [
+                "Small focused pull requests are preferred",
+                "Code reviews improve correctness and maintainability",
+                "At least one reviewer approval is required before merge"
+            ],
+            "expected_sources": [
+                "code_review_guidelines.md"
+            ]
+        }
+    },
+    {
+        "inputs": {
+            "question": "Why did we choose FastAPI?"
+        },
+        "expectations": {
+            "expected_facts": [
+                "FastAPI was chosen for typed validation",
+                "FastAPI supports async endpoints",
+                "Developer ergonomics influenced the decision"
+            ],
+            "expected_sources": [
+                "adr_001_why_fastapi.md"
+            ]
+        }
+    },
+    {
+        "inputs": {
+            "question": "When should an incident be escalated?"
+        },
+        "expectations": {
+            "expected_facts": [
+                "Escalation depends on severity",
+                "High-risk incidents should be escalated early",
+                "Escalation paths are defined in incident policy"
+            ],
+            "expected_sources": [
+                "incident_escalation_policy.md"
+            ]
+        }
+    },
+    {
+        "inputs": {
+            "question": "What rookie mistakes should interns avoid?"
+        },
+        "expectations": {
+            "expected_facts": [
+                "Common mistakes are documented",
+                "Asking too late for help can be a rookie mistake",
+                "Strong interns follow team norms and communicate early"
+            ],
+            "expected_sources": [
+                "rookie_mistakes.md",
+                "what_good_interns_do.md"
+            ]
+        }
+    },
+    {
+        "inputs": {
+            "question": "Why did we choose RAG over fine-tuning?"
+        },
+        "expectations": {
+            "expected_facts": [
+                "RAG was chosen over fine-tuning for knowledge access",
+                "Tradeoffs are described in an ADR",
+                "Maintainability was part of the decision"
+            ],
+            "expected_sources": [
+                "adr_003_why_rag_over_fine_tuning.md"
+            ]
+        }
+    }
+]

--- a/packages/evaluation/pyproject.toml
+++ b/packages/evaluation/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "evaluation"
+version = "0.1.0"
+description = "Evaluation package for Wired Al"
+requires-python = ">=3.13"
+
+dependencies = ["backend", "rag", "mlflow>=3.0", "pandas", "pytest"]
+
+[tool.uv.sources]
+backend = { workspace = true }
+rag = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,18 @@ version = "0.1.0"
 description = "Wired AI LLMOps project"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = ["ipykernel>=7.2.0", "frontend", "backend", "rag"]
+dependencies = ["ipykernel>=7.2.0", "frontend", "backend", "rag", "evaluation"]
 
 [tool.uv.sources]
 backend = { workspace = true }
 frontend = { workspace = true }
 rag = { workspace = true }
+evaluation = { workspace = true }
 
 [tool.uv.workspace]
-members = ["packages/backend", "packages/frontend", "packages/rag"]
+members = [
+    "packages/backend",
+    "packages/frontend",
+    "packages/rag",
+    "packages/evaluation",
+]


### PR DESCRIPTION
## Summary

Adds an initial evaluation package scaffold for future MLflow / LLM judge work.

Includes:
- new `evaluation` package structure
- package-level pyproject
- baseline curated eval dataset (`eval_cases.json`)
- expectations structured around `expected_facts` and `expected_sources`

## Why

Creates a foundation for retrieval and response evaluation without coupling evaluation logic into backend runtime.

Supports future:
- MLflow judge scorers
- retrieval relevance tests
- correctness evaluation

## Scope

This PR intentionally does not include:
- evaluation runner implementation
- MLflow wiring
- production tracing