### PR TITLE
fix(docker): align uv workspace in images and avoid runtime sync failures

### DIFF
--- a/dockerfiles/backend.dockerfile
+++ b/dockerfiles/backend.dockerfile
@@ -9,6 +9,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/backend/pyproject.toml packages/backend/pyproject.toml
 COPY packages/frontend/pyproject.toml packages/frontend/pyproject.toml
 COPY packages/rag/pyproject.toml packages/rag/pyproject.toml
+COPY packages/evaluation/pyproject.toml packages/evaluation/pyproject.toml
 
 # Copy source code needed at runtime
 COPY packages/backend/src/backend packages/backend/src/backend
@@ -19,4 +20,5 @@ COPY packages/rag/knowledge_base packages/rag/knowledge_base
 RUN uv sync --frozen --no-dev --package backend
 
 WORKDIR /app/packages/backend/src/backend
-CMD ["uv", "run", "--package", "backend", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+# --no-sync: use the venv from the image; avoid network/registry on every container start
+CMD ["uv", "run", "--no-sync", "--package", "backend", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/dockerfiles/frontend.dockerfile
+++ b/dockerfiles/frontend.dockerfile
@@ -9,11 +9,15 @@ COPY pyproject.toml uv.lock ./
 COPY packages/backend/pyproject.toml packages/backend/pyproject.toml
 COPY packages/frontend/pyproject.toml packages/frontend/pyproject.toml
 COPY packages/rag/pyproject.toml packages/rag/pyproject.toml
+COPY packages/evaluation/pyproject.toml packages/evaluation/pyproject.toml
 
 # Frontend source
 COPY packages/frontend/src/frontend packages/frontend/src/frontend
 
 RUN uv sync --frozen --no-dev --package frontend
 
+ENV STREAMLIT_SERVER_HEADLESS=true
+
 WORKDIR /app/packages/frontend/src/frontend
-CMD ["uv", "run", "--package", "frontend", "streamlit", "run", "app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]
+# --no-sync: use the venv from the image; avoid network/registry on every container start
+CMD ["uv", "run", "--no-sync", "--package", "frontend", "streamlit", "run", "app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]


### PR DESCRIPTION
# Issue
Containers were exiting on start, so nothing listened on 8000/8501 and the app was unreachable in the browser.

# Solved
- Docker images now include the uv workspace metadata they need (including evaluation) and run the correct app per service (API vs Streamlit).
- Runtime uses uv run --no-sync and Streamlit runs headless in Docker.
- Compose keeps API_URL pointed at the backend service on the internal network.

