### PR TITLE
feat(api): add /documents endpoints (list + fetch)

### DIFF
--- a/packages/backend/src/backend/api.py
+++ b/packages/backend/src/backend/api.py
@@ -1,6 +1,12 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from backend.model import chat
-from backend.schemas import ChatResponse, ChatRequest
+from backend.schemas import (
+    ChatResponse,
+    ChatRequest,
+    DocumentListResponse,
+    DocumentResponse,
+)
+from rag.retrieval import get_document, list_document_names
 
 app = FastAPI()
 
@@ -24,3 +30,19 @@ async def ingest():
         "endpoint": "/ingest",
         "detail": "Not wired to vector ingest; swap to pipeline when ready.",
     }
+
+
+@app.get("/documents", response_model=DocumentListResponse)
+async def list_documents(include_extension: bool = False) -> DocumentListResponse:
+    return DocumentListResponse(
+        documents=list_document_names(include_extension=include_extension)
+    )
+
+
+@app.get("/documents/{document_name}", response_model=DocumentResponse)
+async def get_document_by_name(document_name: str) -> DocumentResponse:
+    normalized = document_name if document_name.endswith(".md") else f"{document_name}.md"
+    doc = get_document(normalized)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return DocumentResponse(**doc)

--- a/packages/backend/src/backend/schemas.py
+++ b/packages/backend/src/backend/schemas.py
@@ -13,6 +13,16 @@ class SourceDocument(BaseModel):
     content_preview: str
 
 
+class DocumentResponse(BaseModel):
+    document_name: str
+    file_path: str
+    content: str
+
+
+class DocumentListResponse(BaseModel):
+    documents: list[str] = Field(default_factory=list)
+
+
 class ChatResponse(BaseModel):
     answer: str
     sources: list[SourceDocument] = Field(default_factory=list)

--- a/packages/rag/src/rag/retrieval.py
+++ b/packages/rag/src/rag/retrieval.py
@@ -15,3 +15,30 @@ def retrieve_documents(query: str, k: int = 3):
         }
         for result in results
     ]
+
+
+def get_document(document_name: str):
+    table = db[TABLE_NAME]
+    df = table.to_pandas()
+    match = df[df["document_name"] == document_name]
+    if match.empty:
+        return None
+
+    row = match.iloc[-1]
+    return {
+        "document_name": str(row["document_name"]),
+        "file_path": str(row["file_path"]),
+        "content": str(row["content"]),
+    }
+
+
+def list_document_names(*, include_extension: bool = False):
+    table = db[TABLE_NAME]
+    df = table.to_pandas()
+    if df.empty or "document_name" not in df.columns:
+        return []
+    # preserve insertion order of first occurrence while de-duping
+    names = list(dict.fromkeys(df["document_name"].astype(str).tolist()))
+    if include_extension:
+        return names
+    return [name.removesuffix(".md") for name in names]


### PR DESCRIPTION
# Summary 
- Add a Documents API to list available knowledge base docs and fetch a specific doc by name.

# Changes
- GET /documents returns document names (defaults to no .md; ?include_extension=true to include it).
- GET /documents/{document_name} returns the full document (document_name, file_path, content) and accepts either rookie_mistakes or rookie_mistakes.md (404 if missing).
- Adds DocumentResponse + DocumentListResponse schemas and LanceDB helpers in rag/retrieval.py.