### PR TITLE
Feat/mlflow docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,25 +25,25 @@ services:
       - API_URL=http://backend:8000
 
   mlflow:
-      container_name: mlflow
-      image: ghcr.io/mlflow/mlflow:latest
-      ports:
-        - "5001:5000"
-      volumes:
-        - mlflow_data:/mlflow # maps named volume mlflow_data into /mlflow folder
-      command:
-        [
-          "mlflow",
-          "server",
-          "--host",
-          "0.0.0.0",
-          "--port",
-          "5000",
-          "--backend-store-uri",
-          "sqlite:////mlflow/mlflow.db",
-          "--allowed-hosts",
-          "*",
-        ]
+    container_name: mlflow
+    image: ghcr.io/mlflow/mlflow:latest
+    ports:
+      - "5001:5000"
+    volumes:
+      - mlflow_data:/mlflow # maps named volume mlflow_data into /mlflow folder
+    command:
+      [
+        "mlflow",
+        "server",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "5000",
+        "--backend-store-uri",
+        "sqlite:////mlflow/mlflow.db",
+        "--allowed-hosts",
+        "*",
+      ]
 
-  volumes:
-    mlflow_data:
+volumes:
+  mlflow_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,3 +23,27 @@ services:
       - backend
     environment:
       - API_URL=http://backend:8000
+
+  mlflow:
+      container_name: mlflow
+      image: ghcr.io/mlflow/mlflow:latest
+      ports:
+        - "5001:5000"
+      volumes:
+        - mlflow_data:/mlflow # maps named volume mlflow_data into /mlflow folder
+      command:
+        [
+          "mlflow",
+          "server",
+          "--host",
+          "0.0.0.0",
+          "--port",
+          "5000",
+          "--backend-store-uri",
+          "sqlite:////mlflow/mlflow.db",
+          "--allowed-hosts",
+          "*",
+        ]
+
+  volumes:
+    mlflow_data:


### PR DESCRIPTION
# Summary
- Adds an mlflow service to docker-compose.yaml.
- Persists MLflow state via a named volume (mlflow_data) and runs with a SQLite backend store.


NOTE: I have also created mlflow container app on Azure, which is ready for our mlflowdb (Fileshare) to be mounted on!