### PR TITLE
feat: prepare MLflow for shared remote tracking server

### DIFF
--- a/packages/backend/src/backend/constants.py
+++ b/packages/backend/src/backend/constants.py
@@ -1,3 +1,5 @@
+import mlflow
+import os 
 from pathlib import Path
 
 
@@ -8,7 +10,7 @@ ROOT_PATH = BASE_PATH.parents[0]
 PROMPTS_PATH = BASE_PATH / "backend" / "src" / "backend" / "prompts"
 MLFLOW_PATH = ROOT_PATH / "mlflow"
 
-MLFLOW_DB_PATH = f"sqlite:///{MLFLOW_PATH}/mlflow.db"
+MLFLOW_DB_PATH = os.getenv("MLFLOW_TRACKING_URI","http://localhost:5001")
 
 DATA_PATH = BASE_PATH / "rag" / "data"
 VECTOR_DB_PATH = BASE_PATH / "rag" / "knowledge_base"
@@ -24,3 +26,5 @@ MODEL_MEDIUM = "google-gla:gemini-3-flash-preview"
 MODEL_LARGE = "openrouter:nvidia/nemotron-3-super-120b-a12b:free"
 
 LLM_JUDGE = "openrouter:/nvidia/nemotron-3-nano-30b-a3b:free"
+
+mlflow.set_tracking_uri(MLFLOW_DB_PATH)

--- a/packages/backend/src/backend/prompt_registry.py
+++ b/packages/backend/src/backend/prompt_registry.py
@@ -3,7 +3,6 @@ from backend.constants import PROMPTS_PATH, MLFLOW_DB_PATH
 from mlflow.genai import register_prompt
 
 def register_prompts(**kwargs):
-    mlflow.set_tracking_uri(MLFLOW_DB_PATH)
     mlflow.set_experiment("wired-al-prompts")
     for filepath in PROMPTS_PATH.glob("*.md"):
         with open(filepath) as file:


### PR DESCRIPTION
## Summary

Prepares MLflow configuration for a shared remote tracking server setup.

### Changes

* replaced hardcoded MLflow DB path usage with environment-based `MLFLOW_TRACKING_URI`
* added support for local fallback via `.env`
* updated backend/evaluation MLflow configuration to use tracking URI consistently
* prepared infrastructure for migrating MLflow backend store from SQLite to PostgreSQL

### Motivation

SQLite worked for local development but caused locking issues when used as a shared remote backend on Azure Container Apps. This change decouples the application code from the underlying database implementation and enables migration to a proper shared backend store.