### PR TITLE
Fix/debug imports mlflow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     image: backend:v1
     ports:
       - "8000:8000"
+  #    volumes: ./packages/backend/src/backend/prompts/system_prompt.md:/prompts/system_prompt/1
 
   frontend:
     container_name: frontend
@@ -31,18 +32,4 @@ services:
       - "5001:5000"
     volumes:
       - ./mlflow:/mlflow # persist DB/artifacts under repo ./mlflow
-    command:
-      [
-        "mlflow",
-        "server",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "5000",
-        "--backend-store-uri",
-        "sqlite:////mlflow/mlflow.db",
-        "--allowed-hosts",
-        "*",
-      ]
-
-volumes: {}
+    command: [ "sh", "-c", "pip install psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri postgresql+psycopg2://mlflowadmin:duzmes-2mucby-xucZaw@wiredal-mlflow.postgres.database.azure.com:5432/mlflow --default-artifact-root /mlflow/artifacts --allowed-hosts '*' --cors-allowed-origins '*'" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     image: backend:v1
     ports:
       - "8000:8000"
+    environment:
+    - MLFLOW_TRACKING_URI=http://mlflow:5000
 
   frontend:
     container_name: frontend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     image: backend:v1
     ports:
       - "8000:8000"
-    #    volumes: ./packages/backend/src/backend/prompts/system_prompt.md:/prompts/system_prompt/1
+    depends_on:
+      - mlflow
     environment:
-      - MLFLOW_TRACKING_URI=http://mlflow:5000
-
+      - MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}
   frontend:
     container_name: frontend
     build:
@@ -34,4 +34,6 @@ services:
       - "5001:5000"
     volumes:
       - ./mlflow:/mlflow # persist DB/artifacts under repo ./mlflow
-    command: [ "sh", "-c", "pip install psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri postgresql+psycopg2://mlflowadmin:duzmes-2mucby-xucZaw@wiredal-mlflow.postgres.database.azure.com:5432/mlflow --default-artifact-root /mlflow/artifacts --allowed-hosts '*' --cors-allowed-origins '*'" ]
+    environment:
+      - MLFLOW_BACKEND_STORE_URI=${MLFLOW_BACKEND_STORE_URI}
+    command: [ "sh", "-c", "pip install psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri \"$MLFLOW_BACKEND_STORE_URI\" --default-artifact-root /mlflow/artifacts --allowed-hosts '*' --cors-allowed-origins '*'" ]

--- a/dockerfiles/backend.dockerfile
+++ b/dockerfiles/backend.dockerfile
@@ -19,6 +19,6 @@ COPY packages/rag/knowledge_base packages/rag/knowledge_base
 # Sync only backend project (and its workspace deps like rag)
 RUN uv sync --frozen --no-dev --package backend
 
-WORKDIR /app/packages/backend/src/backend
+WORKDIR /app/packages/backend/src/backend/
 # --no-sync: use the venv from the image; avoid network/registry on every container start
 CMD ["uv", "run", "--no-sync", "--package", "backend", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/packages/backend/src/backend/constants.py
+++ b/packages/backend/src/backend/constants.py
@@ -1,5 +1,5 @@
 import mlflow
-import os 
+import os
 from pathlib import Path
 
 
@@ -10,7 +10,7 @@ ROOT_PATH = BASE_PATH.parents[0]
 PROMPTS_PATH = BASE_PATH / "backend" / "src" / "backend" / "prompts"
 MLFLOW_PATH = ROOT_PATH / "mlflow"
 
-MLFLOW_DB_PATH = os.getenv("MLFLOW_TRACKING_URI","http://localhost:5001")
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI")
 
 DATA_PATH = BASE_PATH / "rag" / "data"
 VECTOR_DB_PATH = BASE_PATH / "rag" / "knowledge_base"
@@ -27,4 +27,4 @@ MODEL_LARGE = "openrouter:nvidia/nemotron-3-super-120b-a12b:free"
 
 LLM_JUDGE = "openrouter:/nvidia/nemotron-3-nano-30b-a3b:free"
 
-mlflow.set_tracking_uri(MLFLOW_DB_PATH)
+mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)

--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -3,13 +3,14 @@ from mlflow.genai import load_prompt
 from dotenv import load_dotenv
 from pydantic_ai import Agent
 
-from backend.constants import MODEL_MEDIUM, MLFLOW_DB_PATH
+from backend.constants import MODEL_MEDIUM, MLFLOW_TRACKING_URI
 from backend.schemas import ChatResponse, SourceDocument
 
 from rag.retrieval import retrieve_documents
 
 load_dotenv()
-mlflow.set_tracking_uri(MLFLOW_DB_PATH)
+if MLFLOW_TRACKING_URI:
+    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
 system_prompt = load_prompt("prompts:/system_prompt/1").template
 rag_prompt = load_prompt("prompts:/rag_prompt/1").template

--- a/packages/backend/src/backend/prompt_registry.py
+++ b/packages/backend/src/backend/prompt_registry.py
@@ -1,6 +1,7 @@
 import mlflow
-from backend.constants import PROMPTS_PATH, MLFLOW_DB_PATH
+from backend.constants import PROMPTS_PATH, MLFLOW_TRACKING_URI
 from mlflow.genai import register_prompt
+
 
 def register_prompts(**kwargs):
     mlflow.set_experiment("wired-al-prompts")
@@ -8,10 +9,10 @@ def register_prompts(**kwargs):
         with open(filepath) as file:
             filename = filepath.stem
             prompt = file.read()
-            
-        register_prompt(name=filename,template=prompt, **kwargs)
-        
+
+        register_prompt(name=filename, template=prompt, **kwargs)
+
 
 if __name__ == "__main__":
     register_prompts()
-    print(MLFLOW_DB_PATH)
+    print(MLFLOW_TRACKING_URI)

--- a/packages/backend/src/backend/prompts/fun_prompt.md
+++ b/packages/backend/src/backend/prompts/fun_prompt.md
@@ -1,0 +1,1 @@
+Testing testing

--- a/packages/evaluation/src/evaluation/run_eval.py
+++ b/packages/evaluation/src/evaluation/run_eval.py
@@ -6,7 +6,7 @@ from mlflow.genai import evaluate
 from mlflow.genai.datasets import create_dataset
 from mlflow.genai.scorers import Correctness, RetrievalRelevance, RelevanceToQuery
 
-from backend.constants import LLM_JUDGE, MLFLOW_DB_PATH, EVAL_DATA_PATH
+from backend.constants import LLM_JUDGE, MLFLOW_TRACKING_URI, EVAL_DATA_PATH
 from backend.model import chat
 
 
@@ -20,7 +20,7 @@ def bot_answer(question: str):
 
 
 def main() -> None:
-    mlflow.set_tracking_uri(MLFLOW_DB_PATH)
+    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
     experiment = mlflow.set_experiment(experiment_name="wired_al_evaluation")
 


### PR DESCRIPTION
## Summary

Adds remote MLflow tracking integration and updates the stack to use a shared MLflow server instead of local-only tracking.

## Changes

* Added MLflow tracking URI configuration via environment variables
* Connected backend to remote MLflow server
* Updated Docker Compose orchestration for MLflow integration
* Added PostgreSQL MLflow backend support
* Fixed backend ↔ MLflow service connectivity
* Enabled centralized prompt registry usage

## Result

The team can now share prompts, runs, evaluations, and tracking data through a centralized MLflow instance instead of separate local SQLite databases.