### PR TITLE
fix: rag config and safe retrieval

### DIFF
--- a/packages/rag/pyproject.toml
+++ b/packages/rag/pyproject.toml
@@ -2,8 +2,4 @@
 name = "rag"
 version = "0.1.0"
 requires-python = ">=3.13"
-dependencies = ["backend", "pandas<3", "lancedb==0.17"]
-
-
-[tool.uv.sources]
-backend = { workspace = true }
+dependencies = ["pandas<3", "lancedb==0.17", "python-dotenv"]

--- a/packages/rag/src/rag/constants.py
+++ b/packages/rag/src/rag/constants.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+RAG_PACKAGE_PATH = Path(__file__).parents[2].resolve()
+
+DATA_PATH = RAG_PACKAGE_PATH / "data"
+VECTOR_DB_PATH = RAG_PACKAGE_PATH / "knowledge_base"
+
+TABLE_NAME = "articles"
+
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "embed-multilingual-light-v3.0")

--- a/packages/rag/src/rag/data_models.py
+++ b/packages/rag/src/rag/data_models.py
@@ -1,7 +1,7 @@
 from lancedb.pydantic import LanceModel, Vector
 from lancedb.embeddings import get_registry
 
-from backend.constants import EMBEDDING_MODEL
+from rag.constants import EMBEDDING_MODEL
 
 embedding_model = get_registry().get("cohere").create(name=EMBEDDING_MODEL)
 

--- a/packages/rag/src/rag/ingestion.py
+++ b/packages/rag/src/rag/ingestion.py
@@ -1,15 +1,15 @@
 import lancedb
-from backend.constants import VECTOR_DB_PATH, DATA_PATH
-from rag.data_models import Article
 from dotenv import load_dotenv
+
+from rag.constants import VECTOR_DB_PATH, DATA_PATH, TABLE_NAME
+from rag.data_models import Article
 
 load_dotenv()
 
 
 def setup_vector_db():
     db = lancedb.connect(VECTOR_DB_PATH)
-
-    db.create_table("articles", schema=Article, exist_ok=True)
+    db.create_table(TABLE_NAME, schema=Article, exist_ok=True)
 
     return db
 
@@ -26,4 +26,4 @@ def ingest_docs(table):
 
 if __name__ == "__main__":
     db = setup_vector_db()
-    ingest_docs(db["articles"])
+    ingest_docs(db[TABLE_NAME])

--- a/packages/rag/src/rag/retrieval.py
+++ b/packages/rag/src/rag/retrieval.py
@@ -1,10 +1,20 @@
 import lancedb
-from backend.constants import VECTOR_DB_PATH, TABLE_NAME
+from rag.constants import VECTOR_DB_PATH, TABLE_NAME
 
 db = lancedb.connect(VECTOR_DB_PATH)
 
 
-def retrieve_documents(query: str, k: int = 3):
+def get_table():
+    if TABLE_NAME not in db.table_names():
+        return None
+    return db[TABLE_NAME]
+
+
+def retrieve_documents(query: str, k: int = 3) -> list[dict]:
+    table = get_table()
+    if table is None:
+        return []
+
     results = db[TABLE_NAME].search(query).limit(k).to_list()
     return [
         {
@@ -17,8 +27,11 @@ def retrieve_documents(query: str, k: int = 3):
     ]
 
 
-def get_document(document_name: str):
-    table = db[TABLE_NAME]
+def get_document(document_name: str) -> dict | None:
+    table = get_table()
+    if table is None:
+        return None
+
     df = table.to_pandas()
     match = df[df["document_name"] == document_name]
     if match.empty:
@@ -32,13 +45,18 @@ def get_document(document_name: str):
     }
 
 
-def list_document_names(*, include_extension: bool = False):
-    table = db[TABLE_NAME]
+def list_document_names(*, include_extension: bool = False) -> list[str]:
+    table = get_table()
+    if table is None:
+        return []
+
     df = table.to_pandas()
     if df.empty or "document_name" not in df.columns:
         return []
     # preserve insertion order of first occurrence while de-duping
     names = list(dict.fromkeys(df["document_name"].astype(str).tolist()))
+
     if include_extension:
         return names
+
     return [name.removesuffix(".md") for name in names]

--- a/uv.lock
+++ b/uv.lock
@@ -3339,16 +3339,16 @@ name = "rag"
 version = "0.1.0"
 source = { editable = "packages/rag" }
 dependencies = [
-    { name = "backend" },
     { name = "lancedb" },
     { name = "pandas" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "backend", editable = "packages/backend" },
     { name = "lancedb", specifier = "==0.17" },
     { name = "pandas", specifier = "<3" },
+    { name = "python-dotenv" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Decouples the RAG package from backend configuration and makes retrieval safer when the LanceDB table is missing.

## Changes
- Adds `rag.constants` for RAG-specific paths and embedding settings
- Updates RAG imports to avoid depending on `backend.constants`
- Removes `backend` as a dependency from the RAG package
- Loads `.env` for RAG-level commands that need embedding provider keys
- Adds safe table lookup before retrieval and document listing

## Test
- `uv run --package rag python -m rag.ingestion`
- `uv run --package rag python -c "from rag.retrieval import retrieve_documents; print(retrieve_documents('code review'))"`
- `uv run --package backend python -c "from backend.model import chat; print('backend model import ok')"`