### PR TITLE
docs: add missing evaluation source documents

### DIFF
--- a/packages/rag/data/adr_003_why_rag_over_fine_tuning.md
+++ b/packages/rag/data/adr_003_why_rag_over_fine_tuning.md
@@ -1,0 +1,225 @@
+# adr_003_why_rag_over_fine_tuning.md
+
+## ADR-003: Why We Chose RAG Over Fine-Tuning
+
+**Status:** Accepted  
+**Date:** 2026-05-09  
+**Decision owners:** 404 Brain Not Found engineering team  
+**Related system:** Wired Al onboarding copilot
+
+---
+
+# Context
+
+Wired Al is an AI onboarding copilot for interns and junior engineers.
+It answers questions about company knowledge, engineering workflow, cultural expectations and escalation decisions.
+
+The system needs access to information such as:
+
+* onboarding material
+* code review guidelines
+* engineering handbook content
+* architectural decision records
+* runbooks
+* incident and escalation policies
+* examples of good and bad pull requests
+* cultural expectations for interns
+
+This information changes over time.
+Policies are updated, architecture decisions are added, workflows evolve and new examples are created.
+
+The team considered two main approaches:
+
+1. Retrieval-Augmented Generation, also called RAG.
+2. Fine-tuning a language model on company documents.
+
+---
+
+# Decision
+
+We chose RAG over fine-tuning for Wired Al.
+
+The system should retrieve relevant company documents at answer time and generate responses grounded in that retrieved context.
+
+Fine-tuning is not used as the primary method for storing company knowledge.
+
+---
+
+# Why RAG Fits This Project
+
+## 1. Company knowledge changes often
+
+Wired Al depends on documents that may change during the project.
+Examples include onboarding checklists, runbooks, escalation policies and ADRs.
+
+With RAG, we can update or add documents and re-run ingestion.
+The model can then retrieve the new content without retraining the model itself.
+
+With fine-tuning, updated knowledge usually requires a new training process or dataset preparation step.
+That is too heavy for this project and too slow for a realistic onboarding knowledge base.
+
+---
+
+## 2. We need source-grounded answers
+
+Wired Al should show which documents influenced an answer.
+This is important because interns should be able to verify advice against company documentation.
+
+RAG supports this directly by returning source documents with the generated answer.
+
+Fine-tuning does not naturally provide source attribution.
+A fine-tuned model may answer from learned patterns, but it cannot reliably explain which internal document the answer came from unless retrieval or citation logic is added separately.
+
+---
+
+## 3. Maintainability is more important than model specialization
+
+The goal of Wired Al is not to create a model with a unique writing style.
+The goal is to provide useful, current and grounded onboarding support.
+
+RAG keeps knowledge in editable documents.
+This makes the system easier to maintain:
+
+* non-model files contain the source of truth
+* documents can be reviewed in pull requests
+* changes can be traced in Git
+* bad or outdated information can be fixed without model retraining
+
+Fine-tuning would make knowledge harder to inspect because some behaviour would be stored inside model weights.
+
+---
+
+## 4. The dataset is small and controlled
+
+The current knowledge base is made of a limited number of Markdown documents.
+That is a good fit for retrieval.
+
+Fine-tuning usually makes more sense when there is a larger and carefully prepared dataset, or when the goal is to teach a model a stable style, format or task pattern.
+
+For Wired Al, the stronger need is document access, not model retraining.
+
+---
+
+## 5. RAG is easier to evaluate for this use case
+
+The team can evaluate whether:
+
+* the answer is relevant to the user question
+* the retrieved sources are relevant
+* expected source documents are returned
+* the answer is grounded in the knowledge base
+
+This matches the LLMOps goals of the project.
+It also fits MLflow evaluation better because retrieval relevance and answer correctness can be evaluated separately.
+
+With fine-tuning, it would be harder to separate whether a good or bad answer came from training data, prompt design or model behaviour.
+
+---
+
+# Alternatives Considered
+
+## Option A: Fine-tune a model on all company documents
+
+Rejected.
+
+Reasons:
+
+* too much operational overhead for the project scope
+* harder to update when documents change
+* weak source traceability
+* higher risk of stale knowledge
+* harder to debug incorrect answers
+
+Fine-tuning may still be useful in the future for tone, formatting or classification behaviour, but not as the main knowledge mechanism.
+
+---
+
+## Option B: Prompt-only chatbot without retrieval
+
+Rejected.
+
+Reasons:
+
+* limited context window
+* higher hallucination risk
+* difficult to keep answers aligned with changing documentation
+* no reliable source list
+* poor fit for onboarding questions that depend on specific internal policies
+
+---
+
+## Option C: RAG with structured sources
+
+Accepted.
+
+Reasons:
+
+* keeps company knowledge outside the model
+* supports source display
+* easier to update and maintain
+* easier to evaluate
+* fits the project requirement for a document-grounded AI assistant
+* works well with FastAPI, LanceDB, MLflow and the current monorepo structure
+
+---
+
+# Consequences
+
+## Positive Consequences
+
+* Knowledge can be updated by editing Markdown documents.
+* Answers can include source documents.
+* The system is easier to debug.
+* Evaluation can check both answer quality and retrieval quality.
+* The architecture is easier to explain in the project presentation.
+* The team can improve retrieval without changing the LLM.
+
+---
+
+## Negative Consequences
+
+* Retrieval quality becomes critical.
+* Bad chunking or missing ingestion can cause weak answers.
+* The vector database must be built and available at runtime.
+* The system needs clear behaviour when no relevant document is found.
+* The answer quality depends on both retrieval and generation.
+
+---
+
+# Implementation Notes
+
+The chosen flow is:
+
+1. User asks a question.
+2. Backend receives the question through FastAPI.
+3. RAG retrieves relevant documents from LanceDB.
+4. The retrieved context is inserted into the prompt.
+5. The model generates a structured answer.
+6. The API returns the answer and source documents.
+7. Evaluation checks answer quality and retrieval relevance.
+
+The system should not answer as if unsupported information is known.
+If the retrieved context is insufficient, Wired Al should say that the knowledge base does not contain enough information.
+
+---
+
+# When Fine-Tuning Might Be Reconsidered
+
+Fine-tuning may be reconsidered later if the team needs:
+
+* a highly specific and stable response format
+* classification behaviour that is hard to prompt reliably
+* a model that consistently follows the company tone
+* lower latency for repeated known tasks
+* enough high-quality training examples to justify the cost
+
+Even then, RAG would probably remain the source of factual company knowledge.
+Fine-tuning would support behaviour, not replace retrieval.
+
+---
+
+# Final Decision
+
+RAG is the correct primary architecture for Wired Al because the system depends on changing company knowledge, source-grounded answers and maintainable documentation.
+
+Fine-tuning is not rejected as a technology, but it is not the right mechanism for storing onboarding knowledge in this project.

--- a/packages/rag/data/what_good_interns_do.md
+++ b/packages/rag/data/what_good_interns_do.md
@@ -1,0 +1,276 @@
+# what_good_interns_do.md
+
+## What Good Interns Do — 404 Brain Not Found
+
+**Version:** 0.1  
+**Purpose:** Describe the behaviours that help interns and junior engineers succeed at 404 Brain Not Found.
+
+---
+
+# Why This Document Exists
+
+Good interns are not expected to know everything.
+They are expected to learn in a visible, structured and responsible way.
+
+At 404 Brain Not Found, strong interns make progress by combining curiosity, communication and engineering discipline.
+
+This document explains what good intern behaviour looks like in practice.
+
+---
+
+# Core Principle
+
+A good intern does not try to appear senior.
+A good intern works in a way that makes their thinking easy to review, support and trust.
+
+That means:
+
+* asking clear questions
+* documenting decisions
+* making small changes
+* communicating blockers early
+* learning from review feedback
+* respecting team workflows
+
+---
+
+# What Good Interns Do
+
+## 1. They clarify the task before building
+
+Before writing code, good interns make sure they understand:
+
+* the user problem
+* the expected outcome
+* the scope of the task
+* where the change belongs in the system
+* how the work will be tested
+
+They do not need a perfect plan, but they should know what they are trying to achieve.
+
+A good starting question is:
+
+> What should be true when this task is done?
+
+---
+
+## 2. They work in small, reviewable steps
+
+Strong interns avoid large, unfocused pull requests.
+
+A good intern prefers:
+
+* one issue per branch
+* one clear purpose per pull request
+* small commits with meaningful messages
+* code that is easy for a reviewer to understand
+
+Small work is easier to review, easier to fix and easier to merge.
+
+---
+
+## 3. They communicate blockers early
+
+Getting stuck is normal.
+Staying stuck silently is the problem.
+
+Good interns try to solve a problem independently first, but they do not disappear for hours without giving context.
+
+A useful rule:
+
+* If blocked for more than 30 minutes, write down what you tried.
+* If still blocked, ask a teammate or supervisor with that context.
+
+Good blocker messages include:
+
+* what you tried
+* what you expected to happen
+* what actually happened
+* the exact error message, if there is one
+* what file, endpoint or command is involved
+
+---
+
+## 4. They ask specific questions
+
+Weak question:
+
+> It does not work. What should I do?
+
+Better question:
+
+> I expected `/ask` to return an answer with sources, but the backend returns a 500 error. I checked the API URL and the request body. The traceback points to LanceDB table lookup. Could this mean ingestion has not run?
+
+Good interns make it easy for others to help them.
+
+---
+
+## 5. They make their thinking visible
+
+Good interns do not only show the final code.
+They also show the reasoning behind decisions.
+
+Examples:
+
+* explaining why a branch was created
+* writing a short PR description
+* linking the issue being solved
+* documenting tradeoffs in an ADR when relevant
+* leaving comments only where the code is not self-explanatory
+
+Visible reasoning builds trust.
+
+---
+
+## 6. They respect the team workflow
+
+Good interns follow the agreed way of working:
+
+* no direct commits to main
+* feature branches for changes
+* pull requests before merge
+* at least one reviewer
+* conventional commit messages
+* update the issue when the task changes status
+
+This is not bureaucracy.
+It protects the team from confusion, lost work and unstable demos.
+
+---
+
+## 7. They test their own work before asking for review
+
+Before opening a pull request, good interns run the smallest relevant test.
+
+Depending on the change, this can mean:
+
+* checking that the app starts
+* calling `/health`
+* sending one request to `/ask`
+* running ingestion after changing RAG documents
+* running one evaluation smoke test
+* checking that the frontend can reach the backend
+
+A reviewer should not be the first person to run the code.
+
+---
+
+## 8. They learn from code review
+
+Good interns do not treat review comments as personal criticism.
+Review is part of engineering.
+
+A good response to feedback is:
+
+* read the comment carefully
+* ask if the feedback is unclear
+* make the change or explain the tradeoff
+* avoid repeating the same issue in the next PR
+
+The goal is not to “win” the review.
+The goal is to improve the system and the developer.
+
+---
+
+## 9. They know when to escalate
+
+Good interns do not escalate every small problem.
+They also do not hide high-risk problems.
+
+Use this guidance:
+
+### Proceed yourself
+
+Proceed when:
+
+* the change is low risk
+* the task is clear
+* you know how to test it
+* failure would be easy to revert
+
+### Ask a teammate first
+
+Ask a teammate when:
+
+* you are blocked after a serious attempt
+* you are unsure which file or package owns the problem
+* the issue affects another person's work
+* the change may expand beyond the original scope
+
+### Escalate to supervisor
+
+Escalate when:
+
+* production or demo stability is at risk
+* secrets may have been committed
+* a merge may break main
+* requirements are unclear and affect project direction
+* the team cannot agree on an architectural decision
+
+Escalation is not failure.
+It is risk management.
+
+---
+
+# Common Rookie Mistakes to Avoid
+
+Good interns actively avoid these patterns:
+
+* working too long without feedback
+* opening huge pull requests
+* changing unrelated files in the same branch
+* hiding uncertainty
+* asking vague questions
+* skipping tests before review
+* copying code without understanding it
+* using LLM-generated code without checking it
+* treating documentation as optional
+* ignoring team norms because “it works locally”
+
+---
+
+# What Supervisors Notice
+
+Supervisors do not only notice technical output.
+They notice how the intern works.
+
+Strong signals:
+
+* clear communication
+* honest status updates
+* thoughtful questions
+* small and safe changes
+* willingness to learn
+* respect for the codebase
+* ability to explain tradeoffs
+
+Weak signals:
+
+* silence when blocked
+* unexplained changes
+* repeated merge conflicts from poor branching
+* overconfidence without tests
+* lack of ownership
+
+---
+
+# Practical Checklist Before Asking for Review
+
+Before asking someone to review your work, check:
+
+- [ ] The branch has one clear purpose.
+- [ ] The code runs locally.
+- [ ] The relevant endpoint, UI flow or script has been tested.
+- [ ] The PR description explains what changed.
+- [ ] The issue has been updated if needed.
+- [ ] Any known limitation is written clearly.
+- [ ] No secrets, local databases or generated cache files are included.
+
+---
+
+# Summary
+
+Good interns do not need to know everything in advance.
+They succeed by making their work clear, small, testable and easy to support.
+
+At 404 Brain Not Found, a strong intern communicates early, follows team norms, learns from review and escalates risk before it becomes damage.


### PR DESCRIPTION
## Summary
Adds the knowledge-base documents referenced by the evaluation cases.

## Changes
- Adds `adr_003_why_rag_over_fine_tuning.md`
- Adds `what_good_interns_do.md`

## Test
- `uv run --package rag python -m rag.ingestion`
- `uv run --package rag python -c "from rag.retrieval import retrieve_documents; print([d['document_name'] for d in retrieve_documents('Why did we choose RAG over fine-tuning?')])"`