### PR TITLE
feat: add structured escalation guidance

### DIFF
--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -12,8 +12,8 @@ load_dotenv()
 if MLFLOW_TRACKING_URI:
     mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
-system_prompt = load_prompt("prompts:/system_prompt/1").template
-rag_prompt = load_prompt("prompts:/rag_prompt/1").template
+system_prompt = load_prompt("prompts:/system_prompt@latest").template
+rag_prompt = load_prompt("prompts:/rag_prompt@latest").template
 
 wired_al_agent = Agent(
     model=MODEL_MEDIUM, system_prompt=system_prompt, output_type=ChatResponse
@@ -34,6 +34,8 @@ async def chat(question: str) -> ChatResponse:
 
     return ChatResponse(
         answer=result.output.answer,
+        escalation_level=result.output.escalation_level,
+        escalation_reason=result.output.escalation_reason,
         sources=[
             SourceDocument(
                 document_name=doc["document_name"],

--- a/packages/backend/src/backend/prompts/system_prompt.md
+++ b/packages/backend/src/backend/prompts/system_prompt.md
@@ -16,7 +16,7 @@ but never let humor reduce clarity.
 - Treat retrieved documents as the source of truth.
 - Do not invent policies, processes, architectural rationale, or facts.
 - If information is missing or uncertain, say so explicitly.
-- For risky or judgment-heavy situations, recommend escalation to a human.
+- For risky or judgment-heavy situations, choose an appropriate escalation_level.
 </guardrails>
 
 <tone>
@@ -33,10 +33,23 @@ but never let humor reduce clarity.
 - If a question is outside available documentation, acknowledge limits clearly.
 </tools>
 
+<escalation_guidance>
+Always choose one escalation_level:
+
+- proceed: The user can safely continue independently.
+- ask_teammate: The user should ask a teammate before continuing, especially for unclear requirements, shared ownership, or moderate uncertainty.
+- escalate_supervisor: The user should escalate to a supervisor/lead for security risk, authentication or authorization changes, production risk, deployment configuration changes, data loss risk, architecture changes, ownership conflicts, or high-risk timing such as late-Friday deploys.
+
+When a situation matches multiple levels, choose the highest-risk applicable level.
+
+Also provide one short escalation_reason.
+</escalation_guidance>
+
 <output>
 Return:
-1. Direct answer
-2. Brief reasoning when useful
-3. Source references when available
+1. answer
+2. escalation_level: proceed | ask_teammate | escalate_supervisor
+3. escalation_reason
+4. source references when available
 </output>
 

--- a/packages/backend/src/backend/schemas.py
+++ b/packages/backend/src/backend/schemas.py
@@ -23,6 +23,15 @@ class DocumentListResponse(BaseModel):
     documents: list[str] = Field(default_factory=list)
 
 
+EscalationLevel = Literal["proceed", "ask_teammate", "escalate_supervisor"]
+
+
 class ChatResponse(BaseModel):
     answer: str
+    escalation_level: EscalationLevel = Field(
+        description="Recommended action level for the user."
+    )
+    escalation_reason: str = Field(
+        description="Short explanation for why this escalation level was chosen."
+    )
     sources: list[SourceDocument] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
Adds structured escalation guidance to the agent response.

## Changes
- Extends `ChatResponse` with `escalation_level` and `escalation_reason`
- Updates agent response handling to preserve structured escalation fields
- Updates the system prompt with escalation decision rules

## Why
Escalation guidance is part of the initial Wired Al concept and makes the app more than a standard RAG chatbot.

## Test
- `uv run --package backend python -c "from backend.model import chat; print('backend model import ok')"`
- Tested high-risk PR/deployment question and verified `escalation_level: escalate_supervisor`
- Tested documentation lookup question and verified `escalation_level: proceed`

## Follow-up
- Frontend can display `escalation_level` and `escalation_reason`
- Evaluation can add escalation-specific checks later