### PR TITLE
fix: agent prompt loading

### DIFF
--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -69,8 +69,3 @@ async def chat(question: str) -> ChatResponse:
             for doc in documents
         ],
     )
-
-
-@wired_al_agent.tool_plain
-def search_knowledge_base(query: str):
-    return str(retrieve_documents(query))

--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -3,17 +3,43 @@ from mlflow.genai import load_prompt
 from dotenv import load_dotenv
 from pydantic_ai import Agent
 
-from backend.constants import MODEL_MEDIUM, MLFLOW_TRACKING_URI
+from backend.constants import MODEL_MEDIUM, MLFLOW_TRACKING_URI, PROMPTS_PATH
 from backend.schemas import ChatResponse, SourceDocument
 
 from rag.retrieval import retrieve_documents
 
 load_dotenv()
+
 if MLFLOW_TRACKING_URI:
     mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
-system_prompt = load_prompt("prompts:/system_prompt/1").template
-rag_prompt = load_prompt("prompts:/rag_prompt/1").template
+
+def load_local_prompt(filename: str) -> str:
+    prompt_path = PROMPTS_PATH / filename
+
+    if not prompt_path.exists():
+        raise FileNotFoundError(f"Local fallback prompt not found: {prompt_path}")
+
+    return prompt_path.read_text(encoding="utf-8")
+
+
+def load_prompts() -> tuple[str, str]:
+    try:
+        system_prompt = load_prompt("prompts:/system_prompt@latest").template
+        rag_prompt = load_prompt("prompts:/rag_prompt@latest").template
+        return system_prompt, rag_prompt
+
+    except Exception as e:
+        print(
+            "Could not load prompts from MLflow. "
+            f"Falling back to local prompt files. Reason: {type(e).__name__}"
+        )
+        system_prompt = load_local_prompt("system_prompt.md")
+        rag_prompt = load_local_prompt("rag_prompt.md")
+        return system_prompt, rag_prompt
+
+
+system_prompt, rag_prompt = load_prompts()
 
 wired_al_agent = Agent(
     model=MODEL_MEDIUM, system_prompt=system_prompt, output_type=ChatResponse


### PR DESCRIPTION
## Summary
Makes backend agent startup more robust and simplifies the active RAG flow.

## Changes
- Loads prompts from MLflow prompt registry by default
- Falls back to checked-in prompt files under `backend/prompts` if MLflow prompt loading fails
- Removes the unused retrieval tool from `model.py`
- Keeps the active RAG flow deterministic: retrieve documents first, then call the agent with context

## Why
The backend should still be able to start if MLflow is temporarily unavailable or the prompt registry is not ready. The retrieval tool was not part of the active runtime path because documents are already retrieved before the agent call.

## Test
- `uv run --package backend python -c "from backend.model import chat; print('backend model import ok')"`
- `curl http://127.0.0.1:8000/health`
- `/ask` returns answer and sources