### PR TITLE
Feat/mlflow tracing

### DIFF
--- a/packages/backend/src/backend/model.py
+++ b/packages/backend/src/backend/model.py
@@ -12,6 +12,9 @@ load_dotenv()
 
 if MLFLOW_TRACKING_URI:
     mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+    
+mlflow.set_experiment("wired_al_runtime")
+
 
 
 def load_local_prompt(filename: str) -> str:
@@ -45,7 +48,7 @@ wired_al_agent = Agent(
     model=MODEL_MEDIUM, system_prompt=system_prompt, output_type=ChatResponse
 )
 
-
+@mlflow.trace(name="chat", span_type="CHAIN")
 async def chat(question: str) -> ChatResponse:
     documents = retrieve_documents(question)
 

--- a/packages/evaluation/src/evaluation/run_eval.py
+++ b/packages/evaluation/src/evaluation/run_eval.py
@@ -10,6 +10,7 @@ from backend.constants import LLM_JUDGE, MLFLOW_TRACKING_URI, EVAL_DATA_PATH
 from backend.model import chat
 
 
+@mlflow.trace(name="wired_al_predict", span_type="CHAIN")
 def bot_answer(question: str):
     response = asyncio.run(chat(question))
 
@@ -21,10 +22,11 @@ def bot_answer(question: str):
 
 def main() -> None:
     mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+    mlflow.autolog(disable=True)
 
     experiment = mlflow.set_experiment(experiment_name="wired_al_evaluation")
 
-    with open(EVAL_DATA_PATH) as file:
+    with open() as file:
         eval_data = json.load(file)
 
     evaluation_dataset = create_dataset(

--- a/packages/evaluation/src/evaluation/run_eval.py
+++ b/packages/evaluation/src/evaluation/run_eval.py
@@ -26,7 +26,7 @@ def main() -> None:
 
     experiment = mlflow.set_experiment(experiment_name="wired_al_evaluation")
 
-    with open() as file:
+    with open(EVAL_DATA_PATH) as file:
         eval_data = json.load(file)
 
     evaluation_dataset = create_dataset(

--- a/packages/rag/src/rag/retrieval.py
+++ b/packages/rag/src/rag/retrieval.py
@@ -1,4 +1,5 @@
 import lancedb
+import mlflow
 from rag.constants import VECTOR_DB_PATH, TABLE_NAME
 
 db = lancedb.connect(VECTOR_DB_PATH)
@@ -15,16 +16,36 @@ def retrieve_documents(query: str, k: int = 3) -> list[dict]:
     if table is None:
         return []
 
-    results = db[TABLE_NAME].search(query).limit(k).to_list()
-    return [
-        {
-            "document_name": result["document_name"],
-            "file_path": result["file_path"],
-            "content": result["content"],
-            "distance": result["_distance"],
-        }
-        for result in results
-    ]
+    with mlflow.start_span(name="retrieve_documents", span_type="RETRIEVER") as span:
+        span.set_inputs({"query": query, "k": k})
+
+        results = table.search(query).limit(k).to_list()
+
+        documents = [
+            {
+                "document_name": result["document_name"],
+                "file_path": result["file_path"],
+                "content": result["content"],
+                "distance": result["_distance"],
+            }
+            for result in results
+        ]
+
+        span.set_outputs(
+            [
+                {
+                    "page_content": doc["content"],
+                    "metadata": {
+                        "doc_uri": doc["file_path"],
+                        "document_name": doc["document_name"],
+                        "distance": doc["distance"],
+                    },
+                    "id": doc["document_name"],
+                }
+                for doc in documents
+            ]
+        )
+        return documents
 
 
 def get_document(document_name: str) -> dict | None:


### PR DESCRIPTION
## Summary

This PR adds MLflow tracing for the evaluation and runtime chat flows, including retrieval spans that follow MLflow’s expected format.

The goal is to make it easier to inspect how the agent answers questions, which documents are retrieved, and how the evaluation performs in MLflow.

## Changes

- Added tracing for evaluation predictions.
- Added tracing for runtime chat requests.
- Updated document retrieval tracing so MLflow can display retrieved documents correctly.
- Disabled MLflow autologging during evaluation to avoid unrelated logs.

## Testing

Tested the evaluation flow with:

```bash
uv run --package evaluation python -m evaluation.run_eval
```

Evaluation completed successfully.