### PR TITLE
fix(frontend): knowledge_base time outs, error handling and sidebar layout

### DIFF
--- a/packages/frontend/src/frontend/pages/Knowledge_Base.py
+++ b/packages/frontend/src/frontend/pages/Knowledge_Base.py
@@ -6,6 +6,8 @@ import httpx
 import streamlit as st
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
+# Azure cold starts and LanceDB scans can exceed httpx’s short default; override in Container App if needed.
+HTTP_TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "120"))
 ASSETS = Path(__file__).resolve().parent.parent / "assets"
 
 
@@ -13,29 +15,49 @@ def display_document_name(raw: str) -> str:
     return raw.replace("_", " ").strip().title()
 
 
+with st.sidebar:
+    st.image(str(ASSETS / "logo-dark.png"))
+
+documents: list[str] = []
+list_error: str | None = None
 try:
-    list_response = httpx.get(f"{API_URL}/documents")
+    list_response = httpx.get(
+        f"{API_URL}/documents",
+        timeout=HTTP_TIMEOUT,
+    )
     list_response.raise_for_status()
     documents = list(list_response.json().get("documents", []))
-except httpx.HTTPError as exc:
-    st.error(f"The backend returned an error while listing documents: {exc}")
-    st.stop()
+except httpx.HTTPStatusError as exc:
+    list_error = f"HTTP {exc.response.status_code}: {exc.response.text}"
 except httpx.RequestError as exc:
-    st.error(f"Could not connect to the backend at {API_URL}. {exc}")
+    # Includes ReadTimeout, ConnectError, etc. (subclasses of RequestError, not HTTPStatusError)
+    list_error = str(exc)
+
+with st.sidebar:
+    st.subheader("Documents")
+    if list_error is not None:
+        st.caption("Could not load the document list.")
+    elif not documents:
+        st.caption("No documents in the index.")
+    else:
+        st.markdown(
+            "\n".join(f"- {display_document_name(name)}" for name in documents)
+        )
+
+st.title("Knowledge base")
+
+if list_error is not None:
+    st.error(
+        f"Could not load documents from `{API_URL}`. {list_error}\n\n"
+        "In Azure Container Apps, set the frontend **API_URL** to your backend’s base URL "
+        "(for example `https://<your-backend-app>.azurecontainerapps.io`, no trailing slash). "
+        "If the backend is slow to start, increase **HTTP_TIMEOUT** (seconds)."
+    )
     st.stop()
 
 if not documents:
     st.info("No documents are available yet. Ingest markdown into LanceDB or check the backend data path.")
     st.stop()
-
-with st.sidebar:
-    st.image(str(ASSETS / "logo-dark.png"))
-    st.subheader("Documents")
-    st.markdown(
-        "\n".join(f"- {display_document_name(name)}" for name in documents)
-    )
-
-st.title("Knowledge base")
 
 choice = st.selectbox(
     "Open a document",
@@ -50,7 +72,10 @@ if choice is None:
 else:
     path = quote(choice, safe="")
     try:
-        doc_response = httpx.get(f"{API_URL}/documents/{path}")
+        doc_response = httpx.get(
+            f"{API_URL}/documents/{path}",
+            timeout=HTTP_TIMEOUT,
+        )
         doc_response.raise_for_status()
         doc = doc_response.json()
     except httpx.HTTPStatusError as exc:
@@ -61,7 +86,7 @@ else:
                 f"Request failed ({exc.response.status_code}): {exc.response.text}"
             )
     except httpx.RequestError as exc:
-        st.error(f"Could not connect to the backend at {API_URL}. {exc}")
+        st.error(f"Could not reach the backend at {API_URL}. {exc}")
     else:
         with st.expander("Metadata", expanded=False):
             st.markdown(f"**document_name:** `{doc.get('document_name', '')}`")


### PR DESCRIPTION
# Summary
Hardens the Streamlit Knowledge Base page for Azure: longer configurable timeouts, correct error handling (timeouts vs HTTP errors), and sidebar logo shown even when the document list fails to load.

Since the error was only relevant to our app on cloud, I tested by navigating through: https://supercoolwebsiteomg.com/Knowledge_Base


FYI: Instead of removing the faulty frontend image inside the ACR, I pushed the fixed one with tag v2 (frontend:v2) and updated the same container app's image (new revision). This went lot quicker than removing the image and app and deploying from scratch. Note that v1 is still inside our ACR, and should not be used.