### PR TITLE
chore(compose): local Postgres + MLflow stack and env decoupling Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,17 @@
 OPENROUTER_API_KEY=<YOUR_KEY>
 COHERE_API_KEY=<YOUR_KEY>
 GOOGLE_API_KEY=<YOUR_KEY>
-MLFLOW_BACKEND_STORE_URI=<YOUR_KEY>
-MLFLOW_TRACKING_URI=<YOUR_KEY>
 OPENAI_API_KEY=<YOUR_KEY>
+MLFLOW_BACKEND_STORE_URI=<YOUR_URI>
+MLFLOW_TRACKING_URI=<YOUR_URI>
+
+# Optional: only for docker-compose backend — MLflow URL on the Docker network (default http://mlflow:5000).
+# Do not use localhost here; use MLFLOW_TRACKING_URI for scripts on your machine (e.g. http://localhost:5001).
+# MLFLOW_TRACKING_URI_DOCKER=http://mlflow:5000
+
+# Optional: local Docker Compose Postgres (defaults: mlflow / mlflow / mlflow if unset).
+# Use a URL-safe password; special characters break the interpolated MLFLOW_BACKEND_STORE_URI in compose.
+# POSTGRES_USER=mlflow
+# POSTGRES_PASSWORD=mlflow
+# POSTGRES_DB=mlflow
+# POSTGRES_PORT=5432

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,54 @@
+# Local stack: Postgres → MLflow → backend. Named volume keeps DB across restarts (avoid `docker compose down -v`).
+# Override POSTGRES_* in .env if you change user/password/db. Use a URL-safe password or encode it in MLFLOW_BACKEND_STORE_URI.
+
 services:
+  postgres:
+    container_name: postgres
+    build:
+      context: .
+      dockerfile: dockerfiles/postgres.dockerfile
+    image: wiredal-postgres:local
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mlflow}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mlflow}
+      POSTGRES_DB: ${POSTGRES_DB:-mlflow}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  mlflow:
+    container_name: mlflow
+    image: ghcr.io/mlflow/mlflow:latest
+    ports:
+      - "5001:5000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./mlflow:/mlflow
+    environment:
+      MLFLOW_BACKEND_STORE_URI: postgresql+psycopg2://${POSTGRES_USER:-mlflow}:${POSTGRES_PASSWORD:-mlflow}@postgres:5432/${POSTGRES_DB:-mlflow}
+    command:
+      [
+        "sh",
+        "-c",
+        "pip install --no-cache-dir psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri \"$$MLFLOW_BACKEND_STORE_URI\" --default-artifact-root /mlflow/artifacts --allowed-hosts '*' --cors-allowed-origins '*'",
+      ]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/', timeout=2)\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 120s
+
   backend:
     container_name: backend
     build:
-      # . means we are in same folder as docker-compose.yaml file i.e. rag folder
       context: .
       dockerfile: dockerfiles/backend.dockerfile
     env_file:
@@ -11,9 +57,13 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - mlflow
+      mlflow:
+        condition: service_healthy
     environment:
-      - MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}
+      # In Docker, MLflow is reached by service name + container port (not localhost from .env).
+      # Override with MLFLOW_TRACKING_URI_DOCKER in .env if your setup differs; omit for default.
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI_DOCKER:-http://mlflow:5000}
+
   frontend:
     container_name: frontend
     build:
@@ -27,13 +77,5 @@ services:
     environment:
       - API_URL=http://backend:8000
 
-  mlflow:
-    container_name: mlflow
-    image: ghcr.io/mlflow/mlflow:latest
-    ports:
-      - "5001:5000"
-    volumes:
-      - ./mlflow:/mlflow # persist DB/artifacts under repo ./mlflow
-    environment:
-      - MLFLOW_BACKEND_STORE_URI=${MLFLOW_BACKEND_STORE_URI}
-    command: [ "sh", "-c", "pip install psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri \"$MLFLOW_BACKEND_STORE_URI\" --default-artifact-root /mlflow/artifacts --allowed-hosts '*' --cors-allowed-origins '*'" ]
+volumes:
+  postgres_data:

--- a/dockerfiles/postgres.dockerfile
+++ b/dockerfiles/postgres.dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:16-alpine
+
+EXPOSE 5432
+
+HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=5 \
+    CMD pg_isready -h 127.0.0.1 -p 5432 || exit 1

--- a/packages/backend/src/backend/prompt_registry.py
+++ b/packages/backend/src/backend/prompt_registry.py
@@ -1,7 +1,9 @@
+from dotenv import load_dotenv
 import mlflow
 from backend.constants import PROMPTS_PATH, MLFLOW_TRACKING_URI
 from mlflow.genai import register_prompt
 
+load_dotenv()
 
 def register_prompts(**kwargs):
     mlflow.set_experiment("wired-al-prompts")


### PR DESCRIPTION
I could not hold myself back from integrating a part of the “future implementations” we talked about during our demo xd Since I had already deleted the Resource Group on Azure, the product is no longer online, and our local Docker setup was relying on a live MLflow server + PostgreSQL DB.

Instead, I containerized a PostgreSQL DB and connected it to our already existing local MLflow setup. The decoupling I implemented here lets you run the Docker Compose setup almost as if it were still running live in prod on Azure. I thought this could be a nice fix in case you want to show the project to others.

No need to approve the PR yet since we’re still waiting for a grade from Kokchun. I’ll handle it later on.

# Fixes in mind:

- I want to decouple LanceDB as well since it currently lives inside the backend, which is not really ideal
- I think I’ll also look into implementing some auth features for the /ingest endpoint, and if necessary (which it probably will be xd), implement some sort of pipeline to vectorize newly ingested documents
